### PR TITLE
Minor additions and improvements: purge aliases, new rep triggers, etc

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -390,6 +390,7 @@ class Moderation(commands.Cog):
         await ctx.send("\n".join(messages), delete_after=5)
 
     @commands.command()
+    @commands.guild_only()
     @commands.has_permissions(manage_messages=True)
     async def cleanup(self, ctx, search=100):
         """Cleans up the bot's messages from the channel.
@@ -401,7 +402,8 @@ class Moderation(commands.Cog):
             ctx, search, lambda m: m.author == ctx.me or m.content.startswith(ctx.prefix)
         )
 
-    @commands.group(invoke_without_command=True, aliases=("remove",))
+    @commands.group(invoke_without_command=True, aliases=("remove", "clean", "clear",))
+    @commands.guild_only()
     @commands.has_permissions(manage_messages=True)
     async def purge(self, ctx):
         """Mass deletes messages that meet a certain criteria.

--- a/cogs/reputation.py
+++ b/cogs/reputation.py
@@ -11,6 +11,11 @@ GIVEREP_TRIGGERS = [
     "thank",
     "thx",
     "ty",
+    "thnx",
+    "tnx",
+    "tysm",
+    "tyvm",
+    "thanx"
 ]
 
 
@@ -75,6 +80,7 @@ class Reputation(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(aliases=("gr", "+"))
+    @commands.guild_only()
     @commands.cooldown(1, 120, commands.BucketType.user)
     async def giverep(self, ctx, *, user: discord.Member):
         """Gives a reputation point to a user.


### PR DESCRIPTION
+ Added purge aliases: clean, clear 
+ Added new rep_triggers: thnx, tnx, tysm, tyvm, thanx
+ Added commands.guild_only() for the following commands (even though it's not really needed for purge and cleanup, just for code consistency hehe):
    • Purge (cogs/moderation/Line406)
    • Cleanup (cogs/moderation/L393)
    • Giverep (cogs/reputation/L83)

Also, a side note: the ?col command has stopped working, and it doesn't show collecting pokemon of any user. I believe it has something to do with this commit [fdeb1629b9c4b9ad9badd66974e4805d0e8826d9](https://github.com/poketwo/helper-bot/commit/fdeb1629b9c4b9ad9badd66974e4805d0e8826d9) (not sure tho) 