### PR TITLE
Better collectors command formatting; sometimes it shows only the ID, made that a little easier to see the user

### DIFF
--- a/cogs/collectors.py
+++ b/cogs/collectors.py
@@ -98,8 +98,9 @@ class Collectors(commands.Cog):
         def format_item(x):
             user = self.bot.get_user(x["_id"])
             if user is None:
-                return str(x["_id"])
-            return f"{user} {user.mention}"
+                u_id = x["_id"]
+                return f"<@{u_id}> \<@{u_id}>"
+            return f"{user} {user.mention} \<@{user.id}>"
 
         users = self.bot.mongo.db.collector.find({str(species.id): True})
         pages = ViewMenuPages(


### PR DESCRIPTION

- added the @ next to it (sometimes it doesn't show the @ even if the user is in the server/channel)
- added a backslashed @ so you can copy paste to ping for a spawn, etc
- this also helps when it shows @invalid-user (for mobile users)
- this may feel a tad redundant, but it's a QOL change that's quite useful for collector searching