### PR TITLE
Cooldown and cooldown message on the on_message listener for rep triggers.

### DIFF
--- a/cogs/reputation.py
+++ b/cogs/reputation.py
@@ -64,7 +64,7 @@ class Reputation(commands.Cog):
         words = message.content.casefold().split()
         if any(x in words for x in GIVEREP_TRIGGERS):
             ctx = await self.bot.get_context(message)
-            await self.process_giverep(ctx, message.mentions[0])
+            await ctx.invoke(self.bot.get_command('giverep'), user=message.mentions[0])
 
     @commands.command()
     async def rep(self, ctx, *, user: discord.Member = None):


### PR DESCRIPTION
on_message listener now invokes the "giverep" command, that way:
1) The 2m cooldown will actually apply to it. As of now, you can >gr someone and then mention someone else with a rep trigger to rep them too, ignoring the 2m cooldown (the cd assigned to the 'giverep' command, since you can't assign cooldown to an event/listener)
2) It'll actually show the cooldown message when you're on cooldown. (2m or 1h)