### PR TITLE
Shows Ticket ID to the first embed's footer for easier searchability

### DIFF
--- a/cogs/help_desk.py
+++ b/cogs/help_desk.py
@@ -104,6 +104,7 @@ class Ticket(abc.ABC):
             color=discord.Color.blurple(),
         )
         embed.add_field(name="Category", value=self.category.label)
+        embed.set_footer(text=self._id)
         return embed
 
     def to_status_embed(self):


### PR DESCRIPTION
Adds the ticket's ID (e.g. INC 123) to the first embed's footer so that the discord search feature can be used to search for specific tickets.