### PR TITLE
Re-increase ticket thread archive duration

### DIFF
--- a/cogs/help_desk.py
+++ b/cogs/help_desk.py
@@ -292,6 +292,7 @@ class OpenTicketModal(discord.ui.Modal):
         _id = f"{self.category.id.upper()} {await self.bot.mongo.reserve_id(f'ticket_{self.category.id}'):03}"
         thread = await channel.create_thread(
             name=_id,
+            auto_archive_duration=10080,
             type=discord.ChannelType.private_thread,
             invitable=False,
             reason=f"Created support ticket for {interaction.user}",


### PR DESCRIPTION
When the ticket modal was implemented, the auto_archive_duration wasn't re-added, so now all tickets open with a 24h duration which is a problem. This PR fixes that, and makes it so that it opens with a 1 week duration instead like it used to be and like it was implemented in 72a1b5d4f74b2da8eb957ae69fb875c69a67e1a1