### PR TITLE
Automatically append image/gif/video attachment urls to tag content when creating/editing tags

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -161,14 +161,19 @@ class Tags(commands.Cog):
 
     # Writing tags
 
+    @staticmethod
+    def with_attachment_urls(content, attachments):
+        for attachment in attachments:
+            if attachment.content_type.split("/")[0] in ("image", "video"):
+                content += f"\n{attachment.url}"
+        return content
+
     @tag.command()
     @commands.check_any(checks.is_moderator(), commands.has_role("Create Tags"))
     async def create(self, ctx, name, *, content):
         """Creates a new tag owned by you. Attachments will have their URLs appended to the tag."""
 
-        for attachment in ctx.message.attachments:
-            if attachment.content_type.split("/")[0] in ("image", "video"):
-                content += f"\n{attachment.url}"
+        content = self.with_attachment_urls(content, ctx.message.attachments)
 
         if len(content) > CHAR_LIMIT:
             return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
@@ -200,9 +205,7 @@ class Tags(commands.Cog):
     async def edit(self, ctx, name, *, content):
         """Modifies an existing tag that you own. Attachments will have their URLs appended to the tag."""
 
-        for attachment in ctx.message.attachments:
-            if attachment.content_type.split("/")[0] in ("image", "video"):
-                content += f"\n{attachment.url}"
+        content = self.with_attachment_urls(content, ctx.message.attachments)
 
         if len(content) > CHAR_LIMIT:
             return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
@@ -225,9 +228,7 @@ class Tags(commands.Cog):
 
         You must have the Moderator role to use this."""
 
-        for attachment in ctx.message.attachments:
-            if attachment.content_type.split("/")[0] in ("image", "video"):
-                content += f"\n{attachment.url}"
+        content = self.with_attachment_urls(content, ctx.message.attachments)
 
         if len(content) > CHAR_LIMIT:
             return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -171,7 +171,7 @@ class Tags(commands.Cog):
                 content += f"\n{attachment.url}"
 
         if len(content) > CHAR_LIMIT:
-            await ctx.send(f"Tag content (including attachment urls) must be at most {CHAR_LIMIT} characters.")
+            return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
 
         tag = Tag(name=name, owner_id=ctx.author.id, alias=False, content=content)
         try:
@@ -205,7 +205,7 @@ class Tags(commands.Cog):
                 content += f"\n{attachment.url}"
 
         if len(content) > CHAR_LIMIT:
-            await ctx.send(f"Tag content (including attachment urls) must be at most {CHAR_LIMIT} characters.")
+            return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
         if tag is None:
@@ -230,7 +230,7 @@ class Tags(commands.Cog):
                 content += f"\n{attachment.url}"
 
         if len(content) > CHAR_LIMIT:
-            await ctx.send(f"Tag content (including attachment urls) must be at most {CHAR_LIMIT} characters.")
+            return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
         if tag is None:

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -11,6 +11,9 @@ from helpers.pagination import AsyncEmbedListPageSource
 from helpers.utils import FakeUser
 
 
+CHAR_LIMIT = 1994
+
+
 @dataclass
 class Tag:
     name: str
@@ -167,8 +170,8 @@ class Tags(commands.Cog):
             if attachment.content_type.split("/")[0] in ("image", "video"):
                 content += f"\n{attachment.url}"
 
-        if len(content) > 1994:
-            await ctx.send("Tag content (including attachment urls) must be at most 1994 characters.")
+        if len(content) > CHAR_LIMIT:
+            await ctx.send(f"Tag content (including attachment urls) must be at most {CHAR_LIMIT} characters.")
 
         tag = Tag(name=name, owner_id=ctx.author.id, alias=False, content=content)
         try:
@@ -201,8 +204,8 @@ class Tags(commands.Cog):
             if attachment.content_type.split("/")[0] in ("image", "video"):
                 content += f"\n{attachment.url}"
 
-        if len(content) > 1994:
-            await ctx.send("Tag content (including attachment urls) must be at most 1994 characters.")
+        if len(content) > CHAR_LIMIT:
+            await ctx.send(f"Tag content (including attachment urls) must be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
         if tag is None:
@@ -226,8 +229,8 @@ class Tags(commands.Cog):
             if attachment.content_type.split("/")[0] in ("image", "video"):
                 content += f"\n{attachment.url}"
 
-        if len(content) > 1994:
-            await ctx.send("Tag content (including attachment urls) must be at most 1994 characters.")
+        if len(content) > CHAR_LIMIT:
+            await ctx.send(f"Tag content (including attachment urls) must be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
         if tag is None:

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -164,8 +164,7 @@ class Tags(commands.Cog):
     @staticmethod
     def with_attachment_urls(content, attachments):
         for attachment in attachments:
-            if attachment.content_type.split("/")[0] in ("image", "video"):
-                content += f"\n{attachment.url}"
+            content += f"\n{attachment.url}"
         return content
 
     @tag.command()

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -161,10 +161,14 @@ class Tags(commands.Cog):
     @tag.command()
     @commands.check_any(checks.is_moderator(), commands.has_role("Create Tags"))
     async def create(self, ctx, name, *, content):
-        """Creates a new tag owned by you."""
+        """Creates a new tag owned by you. Attach images/gifs/videos to automatically append their urls to the tag."""
+
+        for attachment in ctx.message.attachments:
+            if attachment.content_type.split("/")[0] in ("image", "video"):
+                content += f"\n{attachment.url}"
 
         if len(content) > 1994:
-            await ctx.send("Tag content must be at most 1994 characters.")
+            await ctx.send("Tag content (including attachment urls) must be at most 1994 characters.")
 
         tag = Tag(name=name, owner_id=ctx.author.id, alias=False, content=content)
         try:
@@ -191,7 +195,14 @@ class Tags(commands.Cog):
 
     @tag.command()
     async def edit(self, ctx, name, *, content):
-        """Modifies an existing tag that you own."""
+        """Modifies an existing tag that you own. Attach images/gifs/videos to automatically append their urls to the tag."""
+
+        for attachment in ctx.message.attachments:
+            if attachment.content_type.split("/")[0] in ("image", "video"):
+                content += f"\n{attachment.url}"
+
+        if len(content) > 1994:
+            await ctx.send("Tag content (including attachment urls) must be at most 1994 characters.")
 
         tag = await self.get_tag(name)
         if tag is None:
@@ -207,9 +218,16 @@ class Tags(commands.Cog):
     @tag.command(aliases=("fe",))
     @checks.is_moderator()
     async def forceedit(self, ctx, name, *, content):
-        """Edits a tag by force.
+        """Edits a tag by force. Attach images/gifs/videos to automatically append their urls to the tag.
 
         You must have the Moderator role to use this."""
+
+        for attachment in ctx.message.attachments:
+            if attachment.content_type.split("/")[0] in ("image", "video"):
+                content += f"\n{attachment.url}"
+
+        if len(content) > 1994:
+            await ctx.send("Tag content (including attachment urls) must be at most 1994 characters.")
 
         tag = await self.get_tag(name)
         if tag is None:

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -164,7 +164,7 @@ class Tags(commands.Cog):
     @tag.command()
     @commands.check_any(checks.is_moderator(), commands.has_role("Create Tags"))
     async def create(self, ctx, name, *, content):
-        """Creates a new tag owned by you. Attach images/gifs/videos to automatically append their urls to the tag."""
+        """Creates a new tag owned by you. Attachments will have their URLs appended to the tag."""
 
         for attachment in ctx.message.attachments:
             if attachment.content_type.split("/")[0] in ("image", "video"):
@@ -198,7 +198,7 @@ class Tags(commands.Cog):
 
     @tag.command()
     async def edit(self, ctx, name, *, content):
-        """Modifies an existing tag that you own. Attach images/gifs/videos to automatically append their urls to the tag."""
+        """Modifies an existing tag that you own. Attachments will have their URLs appended to the tag."""
 
         for attachment in ctx.message.attachments:
             if attachment.content_type.split("/")[0] in ("image", "video"):
@@ -221,7 +221,7 @@ class Tags(commands.Cog):
     @tag.command(aliases=("fe",))
     @checks.is_moderator()
     async def forceedit(self, ctx, name, *, content):
-        """Edits a tag by force. Attach images/gifs/videos to automatically append their urls to the tag.
+        """Edits a tag by force. Attachments will have their URLs appended to the tag.
 
         You must have the Moderator role to use this."""
 


### PR DESCRIPTION
This pull request implements a long anticipated feature of being able to send attachments (images/gifs/videos) when creating/editing tags and have their urls be automatically appended to the tag content. Currently the extra hassle of first sending the attachment, copying the link and then pasting into the tag content is needed in order to put attachments into tags. This feature makes it much more intuitive as most (newer) users first try to add attachments this way but to no avail.

This pull request also fixes a bug where there were missing content length checks in edit/forceedit commands, allowing (nitro) users to edit tags to have more than 2000 characters leading to the tag breaking and no longer being shown by the bot due to the bot character limit being 2000, which I assume also raises errors on the bot's end.

Please note that while I have made sure that my code works, I have not tested it on an instance of the bot.