### PR TITLE
Make `content` parameter optional in tag commands

### DIFF
--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -177,7 +177,7 @@ class Tags(commands.Cog):
         if len(content) == 0:
             return await ctx.send_help(ctx.command)
         elif len(content) > CHAR_LIMIT:
-            return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
+            return await ctx.send(f"Tag content (including attachment URLs) can be at most {CHAR_LIMIT} characters.")
 
         tag = Tag(name=name, owner_id=ctx.author.id, alias=False, content=content)
         try:
@@ -211,7 +211,7 @@ class Tags(commands.Cog):
         if len(content) == 0:
             return await ctx.send_help(ctx.command)
         elif len(content) > CHAR_LIMIT:
-            return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
+            return await ctx.send(f"Tag content (including attachment URLs) can be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
         if tag is None:
@@ -236,7 +236,7 @@ class Tags(commands.Cog):
         if len(content) == 0:
             return await ctx.send_help(ctx.command)
         elif len(content) > CHAR_LIMIT:
-            return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
+            return await ctx.send(f"Tag content (including attachment URLs) can be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
         if tag is None:

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -226,7 +226,7 @@ class Tags(commands.Cog):
 
     @tag.command(aliases=("fe",))
     @checks.is_moderator()
-    async def forceedit(self, ctx, name, *, content):
+    async def forceedit(self, ctx, name, *, content = ""):
         """Edits a tag by force. Attachments will have their URLs appended to the tag.
 
         You must have the Moderator role to use this."""

--- a/cogs/tags.py
+++ b/cogs/tags.py
@@ -169,12 +169,14 @@ class Tags(commands.Cog):
 
     @tag.command()
     @commands.check_any(checks.is_moderator(), commands.has_role("Create Tags"))
-    async def create(self, ctx, name, *, content):
+    async def create(self, ctx, name, *, content = ""):
         """Creates a new tag owned by you. Attachments will have their URLs appended to the tag."""
 
         content = self.with_attachment_urls(content, ctx.message.attachments)
 
-        if len(content) > CHAR_LIMIT:
+        if len(content) == 0:
+            return await ctx.send_help(ctx.command)
+        elif len(content) > CHAR_LIMIT:
             return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
 
         tag = Tag(name=name, owner_id=ctx.author.id, alias=False, content=content)
@@ -201,12 +203,14 @@ class Tags(commands.Cog):
             await ctx.send(f'A tag with the name "{tag.name}" already exists.')
 
     @tag.command()
-    async def edit(self, ctx, name, *, content):
+    async def edit(self, ctx, name, *, content = ""):
         """Modifies an existing tag that you own. Attachments will have their URLs appended to the tag."""
 
         content = self.with_attachment_urls(content, ctx.message.attachments)
 
-        if len(content) > CHAR_LIMIT:
+        if len(content) == 0:
+            return await ctx.send_help(ctx.command)
+        elif len(content) > CHAR_LIMIT:
             return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)
@@ -229,7 +233,9 @@ class Tags(commands.Cog):
 
         content = self.with_attachment_urls(content, ctx.message.attachments)
 
-        if len(content) > CHAR_LIMIT:
+        if len(content) == 0:
+            return await ctx.send_help(ctx.command)
+        elif len(content) > CHAR_LIMIT:
             return await ctx.send(f"Tag content (including attachment URLs) must be at most {CHAR_LIMIT} characters.")
 
         tag = await self.get_tag(name)


### PR DESCRIPTION
This PR fixes a small issue related to the previous PR. It makes the content parameter optional, allowing for creation/modification of tags with just attachments.

Oh and in the process i saw that the wording of the content length limit error message was a little off so i fixed that aswell
Thanks <3