### PR TITLE
Fix incorrect number of items shown in pagination

### DIFF
--- a/helpers/pagination.py
+++ b/helpers/pagination.py
@@ -86,7 +86,7 @@ class AsyncEmbedListPageSource(menus.AsyncIteratorPageSource):
             color=discord.Color.blurple(),
             description=f"\n".join(lines),
         )
-        footer = f"Showing entries {start + 1}–{start + len(lines) + 1}"
+        footer = f"Showing entries {start + 1}–{start + len(lines)}"
         if self.count is not None:
             footer += f" out of {self.count}"
         embed.set_footer(text=footer)


### PR DESCRIPTION
This PR fixes a small bug that shows one more than the correct number of items in paginated commands such as `?tag list`
![IMG_20230711_181335](https://github.com/poketwo/guiduck/assets/81734495/42524646-9539-4cbb-b4bd-5943354fd1ba)
