### PR TITLE
Fix error when command ran in DMs

### DIFF
--- a/cogs/levels.py
+++ b/cogs/levels.py
@@ -53,7 +53,8 @@ class Levels(commands.Cog):
 
     @commands.Cog.listener()
     async def on_command(self, ctx):
-        await self.sync_level_roles(ctx.author)
+        if ctx.guild:
+            await self.sync_level_roles(ctx.author)
 
     @commands.Cog.listener()
     async def on_message(self, message):


### PR DESCRIPTION
This on_command event triggers sync_level_roles even if the command is used in DMs. This fills up the logs with errors everytime it's triggered because there is no member.guild. This PR adds a check to make sure it only runs when used in a guild.