### PR TITLE
GUI-12 Make reminders work in DMs

### DIFF
--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -118,7 +118,8 @@ class Reminders(commands.Cog):
 
         def format_item(i, x):
             name = f"{x._id}. {discord.utils.format_dt(x.expires_at, 'R')}"
-            return {"name": name, "value": textwrap.shorten(x.event, 512), "inline": False}
+            message_url = f"https://discord.com/channels/{x.guild_id or '@me'}/{x.channel_id}/{x.message_id}"
+            return {"name": name, "value": f"[{textwrap.shorten(x.event, 512)}]({message_url})", "inline": False}
 
         pages = ViewMenuPages(
             source=AsyncEmbedFieldsPageSource(

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -119,7 +119,7 @@ class Reminders(commands.Cog):
         def format_item(i, x):
             name = f"{x._id}. {discord.utils.format_dt(x.expires_at, 'R')}"
             message_url = f"https://discord.com/channels/{x.guild_id or '@me'}/{x.channel_id}/{x.message_id}"
-            return {"name": name, "value": f"[{textwrap.shorten(x.event, 512)}]({message_url})", "inline": False}
+            return {"name": name, "value": f"{textwrap.shorten(x.event, 512)} [Jump]({message_url})", "inline": False}
 
         pages = ViewMenuPages(
             source=AsyncEmbedFieldsPageSource(

--- a/cogs/reminders.py
+++ b/cogs/reminders.py
@@ -17,7 +17,7 @@ from helpers.utils import FakeUser
 class Reminder:
     user: discord.Member
     event: str
-    guild_id: int
+    guild_id: Optional[int]
     channel_id: int
     message_id: int
     created_at: datetime
@@ -186,7 +186,7 @@ class Reminders(commands.Cog):
             return
 
         await self.bot.mongo.db.reminder.update_one({"_id": reminder._id}, {"$set": {"resolved": True}})
-        if (guild_id := reminder.guild_id):
+        if guild_id := reminder.guild_id:
             guild = self.bot.get_guild(guild_id)
             channel = guild.get_channel_or_thread(reminder.channel_id)
         else:


### PR DESCRIPTION
### Modifications
- Enable reminders in DMs
- Link to reminder messages in reminders list

### Updates since last revision
- Fixed `Reminder` dataclass `guild_id` type annotation from `int` to `Optional[int]` to correctly reflect that DM reminders store `None`
- Applied black formatting

## Summary
Removes `@commands.guild_only()` from the `reminder`, `list`, and `delete` commands so they work in DMs. Stores `guild_id` as `None` for DM reminders and updates `dispatch_reminder` to fall back to `bot.create_dm()` when there's no guild. The reminders list now includes a `[Jump]` link to the original message (using `@me` for DM channels).

The `delete` command no longer filters by `guild_id`, so users can delete any of their reminders from any context (guild or DM).

## Review & Testing Checklist for Human
- [ ] Verify `bot.create_dm(reminder.user)` works when `reminder.user` is a `FakeUser` (i.e. `discord.Object`) — this is the path hit when a DM reminder fires and `build_from_mongo` can't resolve the member from a guild
- [ ] Test setting a reminder in DMs, waiting for it to fire, and confirming the bot DMs you back correctly
- [ ] Test the `[Jump]` link format for DM reminders — confirm `https://discord.com/channels/@me/{channel_id}/{message_id}` resolves properly in the Discord client
- [ ] Confirm that `reminder list` and `reminder delete` still work correctly in guild contexts (no regression from removing `guild_id` filter in delete)

### Notes
- Pre-existing issue (not introduced here): if `guild_id` is non-null but the bot is no longer in that guild, `dispatch_reminder` will crash on `guild.get_channel_or_thread()` since `get_guild()` returns `None`. This affects guild reminders, not DM reminders.

Link to Devin session: https://app.devin.ai/sessions/1401e3e87c5745d8939ca3ca2d16c2bf
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
