### PR TITLE
GUI-20 Fix conversion of Threads and VoiceChannels in logs commands

### DIFF
--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -170,7 +170,7 @@ class Logging(commands.Cog):
     @commands.hybrid_group(fallback="get")
     @checks.is_trial_moderator()
     @commands.guild_only()
-    async def logs(self, ctx, *, channel: discord.TextChannel = None):
+    async def logs(self, ctx, *, channel: discord.TextChannel | discord.Thread | discord.VoiceChannel = None):
         """Gets a link to the message logs for a channel.
 
         You must have the Trial Moderator role to use this.
@@ -182,7 +182,7 @@ class Logging(commands.Cog):
     @logs.command()
     @commands.guild_only()
     @checks.is_community_manager()
-    async def restrict(self, ctx, channel: discord.TextChannel = None):
+    async def restrict(self, ctx, channel: discord.TextChannel | discord.Thread | discord.VoiceChannel = None):
         """Restricts the logs for a channel to Admins.
 
         You must have the Community Manager role to use this.


### PR DESCRIPTION
This PR adds missing support for conversion of Snowflakes and such to Threads or VoiceChannels in logs related commands
![image](https://github.com/poketwo/guiduck/assets/81734495/0e64e98e-928d-44a2-b4a7-ddee1d11ffa0)