### PR TITLE
Add `user`, `limit` and `deleted` flags to logs for filtration

### DIFF
--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -39,6 +39,7 @@ class LogFlags(commands.FlagConverter, case_insensitive=True):
     before: LogFlagConverter = commands.flag(description="Filter logs before a message/datetime", default=None)
     after: LogFlagConverter = commands.flag(description="Filter logs after a message/datetime", default=None)
     limit: int = commands.flag(description="Limit how many logs to show (50 by default)", default=None)
+    deleted: bool = commands.flag(description="Whether to show deleted messages only", default=None)
 
 PARAM_OFFSETS = {"before": 1, "after": -1}
 
@@ -222,6 +223,7 @@ class Logging(commands.Cog):
         > - "ChannelID-MessageID" (retrieved by shift-clicking on “Copy ID”)
         > - Date/time string (e.g. `12/31 16:40`, `friday`, `yesterday`)
         - `limit`: Limit how many logs to show (50 by default)
+        - `deleted`: Whether to show deleted messages only
 
         You must have the Trial Moderator role to use this.
         """
@@ -263,6 +265,10 @@ class Logging(commands.Cog):
         if flags.limit is not None:
             params["limit"] = flags.limit
             filter_texts["Limit"] = flags.limit
+
+        if flags.deleted:
+            params["deleted"] = flags.deleted
+            filter_texts["Deleted Only"] = flags.deleted
 
         if params:
             url += f"?{urlencode(params)}"

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -36,8 +36,8 @@ class LogFlagConverter(commands.Converter):
 
 class LogFlags(commands.FlagConverter, case_insensitive=True):
     user: discord.Member | discord.User = commands.flag(description="Show logs of a specific user", default=None)
-    before: LogFlagConverter = commands.flag(description="Filter logs before a message/datetime", default=None)
-    after: LogFlagConverter = commands.flag(description="Filter logs after a message/datetime", default=None)
+    before: LogFlagConverter = commands.flag(description="Filter logs before a specific message/time", default=None)
+    after: LogFlagConverter = commands.flag(description="Filter logs after a specific message/time", default=None)
     limit: int = commands.flag(description="Limit how many logs to show (50 by default)", default=None)
     deleted: bool = commands.flag(description="Whether to show deleted messages only", default=None)
 

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -35,6 +35,7 @@ class LogFlagConverter(commands.Converter):
 
 
 class LogFlags(commands.FlagConverter, case_insensitive=True):
+    user: discord.Member | discord.User = commands.flag(description="Show logs of a specific user", default=None)
     before: LogFlagConverter = commands.flag(description="Filter logs before a message/datetime", default=None)
     after: LogFlagConverter = commands.flag(description="Filter logs after a message/datetime", default=None)
 
@@ -211,6 +212,7 @@ class Logging(commands.Cog):
     ):
         """Gets a link to the message logs for a channel.
         ### Supported Flags
+        - `user`: Show logs of a specific user
         - `before`: Filter logs before a specific message/time
         - `after`: Filter logs after a specific message/time
         > These accept:
@@ -224,12 +226,17 @@ class Logging(commands.Cog):
 
         url = f"https://admin.poketwo.net/logs/{channel.guild.id}/{channel.id}"
 
-        filter_lines = []
+        params = {}
+        filter_texts = {}
+
+        if flags.user:
+            params["user"] = flags.user.id
+            filter_texts["User"] = flags.user.mention
+
         if flags.before or flags.after:
             if flags.before and flags.after:
                 raise commands.BadArgument("Both `before` and `after` flags cannot be used at the same time.")
 
-            params = {}
             for param in ("before", "after"):
                 value = getattr(flags, param)
                 if not value:
@@ -247,19 +254,21 @@ class Logging(commands.Cog):
                     value_line = format_dt(value, 'F')
                     value = time_snowflake(value)
 
-                if value_line:
-                    filter_lines.append(f"- {param.title()}: {value_line}")
                 params[param] = value
+                if value_line:
+                    filter_texts[param.title()] = value_line
 
-            if filter_lines:
-                filter_lines.insert(0, "### Filters")
-
+        if params:
             url += f"?{urlencode(params)}"
 
         view = discord.ui.View()
         view.add_item(discord.ui.Button(label=f"Jump", url=url))
 
-        lines = [f"### Message Logs of {channel.mention}", url] + filter_lines
+        lines = [f"### Message Logs of {channel.mention}", url]
+        if filter_texts:
+            lines.append("### Filters")
+            lines.extend([f"- **{name}**: {text}" for name, text in filter_texts.items()])
+
         await ctx.send("\n".join(lines), view=view, ephemeral=True)
 
     @logs.command()

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -38,6 +38,7 @@ class LogFlags(commands.FlagConverter, case_insensitive=True):
     user: discord.Member | discord.User = commands.flag(description="Show logs of a specific user", default=None)
     before: LogFlagConverter = commands.flag(description="Filter logs before a message/datetime", default=None)
     after: LogFlagConverter = commands.flag(description="Filter logs after a message/datetime", default=None)
+    limit: int = commands.flag(description="Limit how many logs to show (50 by default)", default=None)
 
 PARAM_OFFSETS = {"before": 1, "after": -1}
 
@@ -220,6 +221,7 @@ class Logging(commands.Cog):
         > - Message ID (current channel)
         > - "ChannelID-MessageID" (retrieved by shift-clicking on “Copy ID”)
         > - Date/time string (e.g. `12/31 16:40`, `friday`, `yesterday`)
+        - `limit`: Limit how many logs to show (50 by default)
 
         You must have the Trial Moderator role to use this.
         """
@@ -257,6 +259,10 @@ class Logging(commands.Cog):
                 params[param] = value
                 if value_line:
                     filter_texts[param.title()] = value_line
+
+        if flags.limit is not None:
+            params["limit"] = flags.limit
+            filter_texts["Limit"] = flags.limit
 
         if params:
             url += f"?{urlencode(params)}"


### PR DESCRIPTION
NOTE: [PR for the logs website](https://github.com/poketwo/admin.poketwo.net/pull/1) needs to be merged before merging this!

- Added a `user` flag to filter message logs by user
- Added a `limit` flag to limit number of messages shown
- Added a `deleted` flag to see only deleted messages