### PR TITLE
Check if giveawayer is suspended when admin approves giveaway request

### DIFF
--- a/cogs/giveaways.py
+++ b/cogs/giveaways.py
@@ -268,18 +268,7 @@ class GiveawayApproveButton(discord.ui.Button):
             member.get("suspended")
             or (member.get("suspended_until") and member.get("suspended_until") > datetime.utcnow())
         ):
-            await self.bot.mongo.db.giveaway.update_one(
-                {"_id": self.giveaway._id}, {"$set": {"approval_status": False}}
-            )
-            await self.giveaway.send_pokemon_to_user(self.giveaway.user)
-
-            embed = await self.giveaway.approval_embed()
-            embed.title = "Giveaway Request Denied"
-            embed.color = discord.Color.red()
-            embed.add_field(name="Reason", value="User is suspended from Pokétwo.", inline=False)
-            await interaction.response.edit_message(embed=embed, view=None)
-            await self.giveaway.user.send(embed=embed)
-            return
+            return await GiveawayDenyButton(self.giveaway).callback(interaction)
 
         await self.bot.mongo.db.giveaway.update_one({"_id": self.giveaway._id}, {"$set": {"approval_status": True}})
 

--- a/cogs/giveaways.py
+++ b/cogs/giveaways.py
@@ -278,6 +278,7 @@ class GiveawayApproveButton(discord.ui.Button):
             embed.color = discord.Color.red()
             embed.add_field(name="Reason", value="User is suspended from Pokétwo.", inline=False)
             await interaction.response.edit_message(embed=embed, view=None)
+            await self.giveaway.user.send(embed=embed)
             return
 
         await self.bot.mongo.db.giveaway.update_one({"_id": self.giveaway._id}, {"$set": {"approval_status": True}})

--- a/cogs/giveaways.py
+++ b/cogs/giveaways.py
@@ -263,6 +263,23 @@ class GiveawayApproveButton(discord.ui.Button):
         self.giveaway = giveaway
 
     async def callback(self, interaction: discord.Interaction):
+        member = await self.bot.mongo.poketwo_db.member.find_one(self.giveaway.user.id)
+        if member is not None and (
+            member.get("suspended")
+            or (member.get("suspended_until") and member.get("suspended_until") > datetime.utcnow())
+        ):
+            await self.bot.mongo.db.giveaway.update_one(
+                {"_id": self.giveaway._id}, {"$set": {"approval_status": False}}
+            )
+            await self.giveaway.send_pokemon_to_user(self.giveaway.user)
+
+            embed = await self.giveaway.approval_embed()
+            embed.title = "Giveaway Request Denied"
+            embed.color = discord.Color.red()
+            embed.add_field(name="Reason", value="User is suspended from Pokétwo.", inline=False)
+            await interaction.response.edit_message(embed=embed, view=None)
+            return
+
         await self.bot.mongo.db.giveaway.update_one({"_id": self.giveaway._id}, {"$set": {"approval_status": True}})
 
         embed = await self.giveaway.approval_embed()
@@ -365,7 +382,18 @@ class Giveaways(commands.Cog):
         species = self.bot.data.species_by_number(p["species_id"])
         iv_total = p["iv_hp"] + p["iv_atk"] + p["iv_defn"] + p["iv_satk"] + p["iv_sdef"] + p["iv_spd"]
         conditions = [
-            any((species.mythical, species.legendary, species.ultra_beast, "-alola" in species.slug, "-galar" in species.slug, "-hisui" in species.slug, "-paldea" in species.slug)) and iv_total >= 112,
+            any(
+                (
+                    species.mythical,
+                    species.legendary,
+                    species.ultra_beast,
+                    "-alola" in species.slug,
+                    "-galar" in species.slug,
+                    "-hisui" in species.slug,
+                    "-paldea" in species.slug,
+                )
+            )
+            and iv_total >= 112,
             species.event and iv_total >= 112,
             iv_total >= 168 or iv_total <= 18,
             p.get("shiny"),
@@ -401,12 +429,18 @@ class Giveaways(commands.Cog):
         """Start a giveaway."""
 
         member = await self.bot.mongo.poketwo_db.member.find_one(ctx.author.id)
-        if member.get("suspended") or (member.get("suspended_until") and member.get("suspended_until") > datetime.utcnow()):
+        if member.get("suspended") or (
+            member.get("suspended_until") and member.get("suspended_until") > datetime.utcnow()
+        ):
             return await ctx.send("Your account is suspended from Pokétwo and can not do giveaways.")
 
-        user_pending_count = await self.bot.mongo.db.giveaway.count_documents({"user_id": ctx.author.id, "approval_status": None})
+        user_pending_count = await self.bot.mongo.db.giveaway.count_documents(
+            {"user_id": ctx.author.id, "approval_status": None}
+        )
         if user_pending_count >= MAX_PENDING_GIVEAWAYS:
-            return await ctx.reply(f"You already have the max number of giveways pending ({MAX_PENDING_GIVEAWAYS}). Please try again once those have been reviewed!")
+            return await ctx.reply(
+                f"You already have the max number of giveways pending ({MAX_PENDING_GIVEAWAYS}). Please try again once those have been reviewed!"
+            )
 
         pokemon = await self.bot.mongo.poketwo_db.pokemon.find_one(
             {"owned_by": "user", "owner_id": ctx.author.id, "idx": pokemon}


### PR DESCRIPTION
## Summary

When an admin clicks "Approve" on a giveaway request, the bot now checks whether the giveaway creator's Pokétwo account is suspended (permanently or temporarily). If suspended, the approval is intercepted and delegated to `GiveawayDenyButton.callback()`, reusing the existing deny flow entirely — the giveaway is denied, escrowed Pokémon are returned, and the user receives a denial DM.

The suspension check mirrors the existing logic in the `giveaway start` command (`member.get("suspended")` / `member.get("suspended_until")`).

The rest of the diff is `black` reformatting existing long lines to comply with the 120-char limit.

## Updates since last revision

- Refactored to delegate to `GiveawayDenyButton(self.giveaway).callback(interaction)` instead of duplicating the denial logic inline. This means the denial looks identical to a manual deny (no special "suspended" reason field on the embed).

## Review & Testing Checklist for Human

- [ ] **No visual distinction for suspension-triggered denials.** Since the deny flow is fully reused, admins won't see any indication that the denial was due to suspension vs. a manual deny. Verify this is acceptable or if a distinguishing reason field is desired.
- [ ] **Pokémon are returned to the suspended user** via `send_pokemon_to_user` (same as normal deny). Confirm this is correct vs. holding them or handling differently for suspended accounts.
- [ ] **Test with both suspension types:** permanently suspended (`suspended: true`) and temporarily suspended (`suspended_until` set to a future date). Also verify that a non-suspended user can still be approved normally.

**Suggested test plan:** In a test environment, create a giveaway request from a user, then suspend that user's Pokétwo account. Click "Approve" on the pending request and verify: (1) the approval embed updates to "Giveaway Request Denied", (2) the user receives a denial DM, (3) the escrowed Pokémon are returned. Then repeat with a non-suspended user to confirm normal approval still works.

### Notes
- The new code adds a `member is not None` guard before checking suspension fields, which is slightly more defensive than the existing check in the `giveaway start` command.

Link to Devin session: https://app.devin.ai/sessions/48df63f28f7644a996771dd57cbc21b5
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
