### PR TITLE
feat: add ?pin command to pin/unpin messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -26,6 +26,7 @@ COGS = [
     "levels",
     "moderation",
     "names",
+    "pins",
     "poketwo_administration",
     "reaction_roles",
     "reminders",

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -54,21 +54,23 @@ class TimedPin:
 
 
 def can_pin():
-    """Check that the user is the thread owner or has manage_messages permission."""
+    """Check that the user is the thread owner or has the pin messages permission."""
 
     async def predicate(ctx):
         if not isinstance(ctx.channel, discord.Thread):
             raise commands.CheckFailure("This command can only be used in threads.")
 
-        # Users with manage_messages can always pin
-        if ctx.channel.permissions_for(ctx.author).manage_messages:
+        perms = ctx.channel.permissions_for(ctx.author)
+
+        # Users with pin_messages (or manage_messages) can always pin
+        if perms.manage_messages or perms.pin_messages:
             return True
 
         # Thread owner can pin in their own thread
         if ctx.channel.owner_id == ctx.author.id:
             return True
 
-        raise commands.CheckFailure("You must be the thread owner or have the Manage Messages permission to use this.")
+        raise commands.CheckFailure("You must be the thread owner or have the Pin Messages permission to use this.")
 
     return commands.check(predicate)
 

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -12,6 +12,12 @@ from discord.utils import format_dt
 from helpers import time
 from helpers.pagination import AsyncEmbedFieldsPageSource
 
+# Discord's PIN_MESSAGES permission (1 << 51), not yet in this discord.py fork
+PIN_MESSAGES_BIT = 1 << 51
+
+# Discord increased the pin limit from 50 to 250 in August 2025
+MAX_PINS = 250
+
 
 @dataclass
 class TimedPin:
@@ -59,8 +65,12 @@ def can_pin():
     async def predicate(ctx):
         perms = ctx.channel.permissions_for(ctx.author)
 
-        # Users with pin_messages (or manage_messages) can always pin
-        if perms.manage_messages or perms.pin_messages:
+        # Users with manage_messages can always pin
+        if perms.manage_messages:
+            return True
+
+        # Check PIN_MESSAGES (1 << 51) via raw value since our discord.py fork doesn't have it yet
+        if perms.value & PIN_MESSAGES_BIT:
             return True
 
         # Thread owner can pin in their own thread
@@ -80,7 +90,7 @@ class PinIndexOrMessage(commands.Converter):
         stripped = argument.lstrip("#")
         if stripped.isdigit():
             idx = int(stripped)
-            if 1 <= idx <= 50:
+            if 1 <= idx <= MAX_PINS:
                 return idx
 
         return await commands.MessageConverter().convert(ctx, argument)
@@ -240,7 +250,7 @@ class Pins(commands.Cog):
         pages = ViewMenuPages(
             source=AsyncEmbedFieldsPageSource(
                 get_pins(),
-                title=f"\N{PUSHPIN} Pinned Messages ({count}/50)",
+                title=f"\N{PUSHPIN} Pinned Messages ({count}/{MAX_PINS})",
                 format_item=format_item,
                 count=count,
             )

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -169,6 +169,10 @@ class Pins(commands.Cog):
             {"$set": {"resolved": True}},
         )
 
+        if self._current is not None:
+            self.clear_current()
+        self.bot.loop.create_task(self.update_current())
+
         await ctx.send("\N{PUSHPIN} Unpinned!")
 
     @pin.command(name="list", aliases=("ls",))
@@ -234,6 +238,10 @@ class Pins(commands.Cog):
             {"channel_id": ctx.channel.id, "resolved": False},
             {"$set": {"resolved": True}},
         )
+
+        if self._current is not None:
+            self.clear_current()
+        self.bot.loop.create_task(self.update_current())
 
         await ctx.send(f"\N{PUSHPIN} Unpinned **{len(pinned)}** messages.")
 

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -2,7 +2,7 @@ import asyncio
 import textwrap
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import discord
 from discord.ext import commands
@@ -83,6 +83,20 @@ def can_pin():
     return commands.check(predicate)
 
 
+class PinIndexOrMessage(commands.Converter):
+    """Accepts either a pin index (e.g. #1, #2) or a message link/ID."""
+
+    async def convert(self, ctx, argument: str) -> Union[int, discord.Message]:
+        # Check for pin index (e.g. #1 or just a small number)
+        stripped = argument.lstrip("#")
+        if stripped.isdigit():
+            idx = int(stripped)
+            if 1 <= idx <= 50:
+                return idx
+
+        return await commands.MessageConverter().convert(ctx, argument)
+
+
 class Pins(commands.Cog):
     """For pinning and unpinning messages in threads."""
 
@@ -109,20 +123,36 @@ class Pins(commands.Cog):
     @commands.guild_only()
     @can_pin()
     async def pin(self, ctx, message: Optional[str] = None, *, flags: PinFlags):
-        """Pins a message in the current thread.
+        """Toggles a pin on a message in the current thread.
 
-        You can reply to the message you want to pin, or pass a message link/ID.
+        If the message is not pinned, it will be pinned. If it is already pinned, it will be unpinned.
+
+        You can reply to the message, or pass a message link/ID.
 
         Use --duration to pin temporarily, e.g.:
-        • ?pin <message> --duration 2h
-        • ?pin --duration 30m (when replying)
+        \u2022 ?pin <message> --duration 2h
+        \u2022 ?pin --duration 30m (when replying)
         """
 
         target = await self.resolve_message(ctx, message)
 
         if target.pinned:
-            return await ctx.send("That message is already pinned.")
+            # Unpin the message (toggle off)
+            await target.unpin(reason=f"Unpinned by {ctx.author} (ID: {ctx.author.id})")
 
+            # Resolve any timed pin for this message
+            await self.bot.mongo.db.timed_pin.update_many(
+                {"message_id": target.id, "channel_id": ctx.channel.id, "resolved": False},
+                {"$set": {"resolved": True}},
+            )
+
+            if self._current is not None:
+                self.clear_current()
+            self.bot.loop.create_task(self.update_current())
+
+            return await ctx.send("\N{PUSHPIN} Unpinned!")
+
+        # Pin the message (toggle on)
         await target.pin(reason=f"Pinned by {ctx.author} (ID: {ctx.author.id})")
 
         if flags.duration is not None:
@@ -147,38 +177,13 @@ class Pins(commands.Cog):
         else:
             await ctx.send("\N{PUSHPIN} Pinned!")
 
-    @pin.command(name="remove", aliases=("unpin",))
-    @commands.guild_only()
-    @can_pin()
-    async def pin_remove(self, ctx, *, message: Optional[str] = None):
-        """Unpins a message in the current thread.
-
-        You can reply to the message you want to unpin, or pass a message link/ID.
-        """
-
-        target = await self.resolve_message(ctx, message)
-
-        if not target.pinned:
-            return await ctx.send("That message is not pinned.")
-
-        await target.unpin(reason=f"Unpinned by {ctx.author} (ID: {ctx.author.id})")
-
-        # Resolve any timed pin for this message
-        await self.bot.mongo.db.timed_pin.update_many(
-            {"message_id": target.id, "channel_id": ctx.channel.id, "resolved": False},
-            {"$set": {"resolved": True}},
-        )
-
-        if self._current is not None:
-            self.clear_current()
-        self.bot.loop.create_task(self.update_current())
-
-        await ctx.send("\N{PUSHPIN} Unpinned!")
-
     @pin.command(name="list", aliases=("ls",))
     @commands.guild_only()
     async def pin_list(self, ctx):
-        """Lists all pinned messages in the current channel."""
+        """Lists all pinned messages in the current channel.
+
+        Use ?pin view <#index> to view a specific pin's full content.
+        """
 
         pinned = await ctx.channel.pins()
 
@@ -195,7 +200,7 @@ class Pins(commands.Cog):
             content = msg.content or "*No text content*"
             preview = textwrap.shorten(content, 100)
             jump = f"[Jump]({msg.jump_url})"
-            name = f"{msg.author.display_name} \u2022 {jump}"
+            name = f"#{i + 1}. {msg.author.display_name} \u2022 {jump}"
             value = f"{preview}\n{format_dt(msg.created_at, 'R')}"
             return {"name": name, "value": value, "inline": False}
 
@@ -213,37 +218,49 @@ class Pins(commands.Cog):
         except IndexError:
             await ctx.send("No pinned messages found.")
 
-    @pin.command(name="clear")
+    @pin.command(name="view", aliases=("show", "info"))
     @commands.guild_only()
-    @can_pin()
-    async def pin_clear(self, ctx):
-        """Unpins all messages in the current thread."""
+    async def pin_view(self, ctx, *, target: PinIndexOrMessage):
+        """Shows a specific pinned message's content in an embed.
 
-        pinned = await ctx.channel.pins()
+        You can pass a message link/ID, or use an index from ?pin list (e.g. #1).
+        """
 
-        if not pinned:
-            return await ctx.send("There are no pinned messages to clear.")
+        if isinstance(target, int):
+            # Resolve index to a pinned message
+            pinned = await ctx.channel.pins()
+            if not pinned:
+                return await ctx.send("There are no pinned messages in this channel.")
+            if target < 1 or target > len(pinned):
+                return await ctx.send(
+                    f"Invalid pin index. There are **{len(pinned)}** pinned messages (use #1-#{len(pinned)})."
+                )
+            message = pinned[target - 1]
+        else:
+            message = target
+            if not message.pinned:
+                return await ctx.send("That message is not pinned.")
 
-        result = await ctx.confirm(f"Are you sure you want to unpin all **{len(pinned)}** pinned messages?")
-
-        if result is None or result is False:
-            return await ctx.send("Cancelled.")
-
-        reason = f"Bulk unpin by {ctx.author} (ID: {ctx.author.id})"
-        for msg in pinned:
-            await msg.unpin(reason=reason)
-
-        # Resolve all timed pins in this channel
-        await self.bot.mongo.db.timed_pin.update_many(
-            {"channel_id": ctx.channel.id, "resolved": False},
-            {"$set": {"resolved": True}},
+        embed = discord.Embed(
+            description=message.content or "*No text content*",
+            color=discord.Color.blurple(),
+            timestamp=message.created_at,
         )
+        embed.set_author(name=message.author.display_name, icon_url=message.author.display_avatar.url)
+        embed.add_field(name="Jump", value=f"[Go to message]({message.jump_url})", inline=True)
 
-        if self._current is not None:
-            self.clear_current()
-        self.bot.loop.create_task(self.update_current())
+        if message.attachments:
+            attachment_text = "\n".join(f"[{a.filename}]({a.url})" for a in message.attachments)
+            embed.add_field(name="Attachments", value=attachment_text, inline=False)
+            # Set the first image attachment as the embed image
+            for attachment in message.attachments:
+                if attachment.content_type and attachment.content_type.startswith("image/"):
+                    embed.set_image(url=attachment.url)
+                    break
 
-        await ctx.send(f"\N{PUSHPIN} Unpinned **{len(pinned)}** messages.")
+        embed.set_footer(text=f"Pin #{target}" if isinstance(target, int) else "Pinned message")
+
+        await ctx.send(embed=embed)
 
     # Timed pin dispatch system (modeled after reminders)
 

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -1,0 +1,311 @@
+import asyncio
+import textwrap
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import discord
+from discord.ext import commands
+from discord.ext.menus.views import ViewMenuPages
+from discord.utils import format_dt
+
+from helpers import time
+from helpers.pagination import AsyncEmbedFieldsPageSource
+
+
+@dataclass
+class TimedPin:
+    user_id: int
+    guild_id: int
+    channel_id: int
+    message_id: int
+    created_at: datetime
+    expires_at: datetime
+    resolved: bool = False
+    _id: int = None
+
+    @classmethod
+    def build_from_mongo(cls, x):
+        return cls(
+            _id=x["_id"],
+            user_id=x["user_id"],
+            guild_id=x["guild_id"],
+            channel_id=x["channel_id"],
+            message_id=x["message_id"],
+            created_at=x["created_at"],
+            expires_at=x["expires_at"],
+            resolved=x.get("resolved", False),
+        )
+
+    def to_dict(self):
+        return {
+            "user_id": self.user_id,
+            "guild_id": self.guild_id,
+            "channel_id": self.channel_id,
+            "message_id": self.message_id,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "resolved": self.resolved,
+        }
+
+    @property
+    def duration(self):
+        return self.expires_at - self.created_at
+
+
+class PinFlags(commands.FlagConverter, prefix="--", delimiter=" "):
+    duration: Optional[time.FutureTime] = commands.flag(
+        name="duration",
+        aliases=("d", "for", "in", "time", "t"),
+        description="Duration to keep the message pinned before auto-unpinning",
+        max_args=1,
+        default=None,
+    )
+
+
+def can_pin():
+    """Check that the user is the thread owner or has manage_messages permission."""
+
+    async def predicate(ctx):
+        if not isinstance(ctx.channel, discord.Thread):
+            raise commands.CheckFailure("This command can only be used in threads.")
+
+        # Users with manage_messages can always pin
+        if ctx.channel.permissions_for(ctx.author).manage_messages:
+            return True
+
+        # Thread owner can pin in their own thread
+        if ctx.channel.owner_id == ctx.author.id:
+            return True
+
+        raise commands.CheckFailure("You must be the thread owner or have the Manage Messages permission to use this.")
+
+    return commands.check(predicate)
+
+
+class Pins(commands.Cog):
+    """For pinning and unpinning messages in threads."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self._current = None
+        self.bot.loop.create_task(self.update_current())
+
+    async def resolve_message(self, ctx, message: Optional[str] = None) -> discord.Message:
+        """Resolve a message from a reply, link, or ID."""
+
+        if message is not None:
+            return await commands.MessageConverter().convert(ctx, message)
+
+        if ctx.message.reference is not None and ctx.message.reference.message_id is not None:
+            try:
+                return await ctx.channel.fetch_message(ctx.message.reference.message_id)
+            except discord.NotFound:
+                raise commands.BadArgument("The replied-to message was not found.")
+
+        raise commands.BadArgument("Please reply to a message or provide a message link/ID.")
+
+    @commands.group(invoke_without_command=True)
+    @commands.guild_only()
+    @can_pin()
+    async def pin(self, ctx, message: Optional[str] = None, *, flags: PinFlags):
+        """Pins a message in the current thread.
+
+        You can reply to the message you want to pin, or pass a message link/ID.
+
+        Use --duration to pin temporarily, e.g.:
+        • ?pin <message> --duration 2h
+        • ?pin --duration 30m (when replying)
+        """
+
+        target = await self.resolve_message(ctx, message)
+
+        if target.pinned:
+            return await ctx.send("That message is already pinned.")
+
+        await target.pin(reason=f"Pinned by {ctx.author} (ID: {ctx.author.id})")
+
+        if flags.duration is not None:
+            timed_pin = TimedPin(
+                user_id=ctx.author.id,
+                guild_id=ctx.guild.id,
+                channel_id=ctx.channel.id,
+                message_id=target.id,
+                created_at=ctx.message.created_at,
+                expires_at=flags.duration.dt,
+            )
+
+            id = await self.bot.mongo.reserve_id("timed_pin")
+            await self.bot.mongo.db.timed_pin.insert_one({"_id": id, **timed_pin.to_dict()})
+
+            timed_pin._id = id
+            self.bot.loop.create_task(self.update_current(timed_pin))
+
+            await ctx.send(
+                f"\N{PUSHPIN} Pinned! This message will be automatically unpinned {format_dt(flags.duration.dt, 'R')}."
+            )
+        else:
+            await ctx.send("\N{PUSHPIN} Pinned!")
+
+    @pin.command(name="remove", aliases=("unpin",))
+    @commands.guild_only()
+    @can_pin()
+    async def pin_remove(self, ctx, *, message: Optional[str] = None):
+        """Unpins a message in the current thread.
+
+        You can reply to the message you want to unpin, or pass a message link/ID.
+        """
+
+        target = await self.resolve_message(ctx, message)
+
+        if not target.pinned:
+            return await ctx.send("That message is not pinned.")
+
+        await target.unpin(reason=f"Unpinned by {ctx.author} (ID: {ctx.author.id})")
+
+        # Resolve any timed pin for this message
+        await self.bot.mongo.db.timed_pin.update_many(
+            {"message_id": target.id, "channel_id": ctx.channel.id, "resolved": False},
+            {"$set": {"resolved": True}},
+        )
+
+        await ctx.send("\N{PUSHPIN} Unpinned!")
+
+    @pin.command(name="list", aliases=("ls",))
+    @commands.guild_only()
+    async def pin_list(self, ctx):
+        """Lists all pinned messages in the current channel."""
+
+        pinned = await ctx.channel.pins()
+
+        if not pinned:
+            return await ctx.send("There are no pinned messages in this channel.")
+
+        count = len(pinned)
+
+        async def get_pins():
+            for msg in pinned:
+                yield msg
+
+        def format_item(i, msg):
+            content = msg.content or "*No text content*"
+            preview = textwrap.shorten(content, 100)
+            jump = f"[Jump]({msg.jump_url})"
+            name = f"{msg.author.display_name} \u2022 {jump}"
+            value = f"{preview}\n{format_dt(msg.created_at, 'R')}"
+            return {"name": name, "value": value, "inline": False}
+
+        pages = ViewMenuPages(
+            source=AsyncEmbedFieldsPageSource(
+                get_pins(),
+                title=f"\N{PUSHPIN} Pinned Messages ({count}/50)",
+                format_item=format_item,
+                count=count,
+            )
+        )
+
+        try:
+            await pages.start(ctx)
+        except IndexError:
+            await ctx.send("No pinned messages found.")
+
+    @pin.command(name="clear")
+    @commands.guild_only()
+    @can_pin()
+    async def pin_clear(self, ctx):
+        """Unpins all messages in the current thread."""
+
+        pinned = await ctx.channel.pins()
+
+        if not pinned:
+            return await ctx.send("There are no pinned messages to clear.")
+
+        result = await ctx.confirm(f"Are you sure you want to unpin all **{len(pinned)}** pinned messages?")
+
+        if result is None or result is False:
+            return await ctx.send("Cancelled.")
+
+        reason = f"Bulk unpin by {ctx.author} (ID: {ctx.author.id})"
+        for msg in pinned:
+            await msg.unpin(reason=reason)
+
+        # Resolve all timed pins in this channel
+        await self.bot.mongo.db.timed_pin.update_many(
+            {"channel_id": ctx.channel.id, "resolved": False},
+            {"$set": {"resolved": True}},
+        )
+
+        await ctx.send(f"\N{PUSHPIN} Unpinned **{len(pinned)}** messages.")
+
+    # Timed pin dispatch system (modeled after reminders)
+
+    async def get_next_timed_pin(self):
+        timed_pin = await self.bot.mongo.db.timed_pin.find_one({"resolved": False}, sort=(("expires_at", 1),))
+        if timed_pin is None:
+            return None
+        return TimedPin.build_from_mongo(timed_pin)
+
+    def clear_current(self):
+        self._current.task.cancel()
+        self._current = None
+
+    async def update_current(self, timed_pin=None):
+        await self.bot.wait_until_ready()
+
+        if timed_pin is None:
+            timed_pin = await self.get_next_timed_pin()
+            if timed_pin is None:
+                return
+
+        if self._current is not None and not self._current.task.done():
+            if timed_pin.expires_at > self._current.timed_pin.expires_at:
+                return
+            self.clear_current()
+
+        self._current = DispatchedTimedPin(
+            timed_pin=timed_pin,
+            task=self.bot.loop.create_task(self.dispatch_timed_pin(timed_pin)),
+        )
+
+    async def dispatch_timed_pin(self, timed_pin):
+        try:
+            await discord.utils.sleep_until(timed_pin.expires_at)
+        except asyncio.CancelledError:
+            return
+
+        await self.bot.mongo.db.timed_pin.update_one({"_id": timed_pin._id}, {"$set": {"resolved": True}})
+
+        guild = self.bot.get_guild(timed_pin.guild_id)
+        if guild is None:
+            self.bot.loop.create_task(self.update_current())
+            return
+
+        channel = guild.get_channel_or_thread(timed_pin.channel_id)
+        if channel is None:
+            self.bot.loop.create_task(self.update_current())
+            return
+
+        try:
+            message = await channel.fetch_message(timed_pin.message_id)
+            if message.pinned:
+                await message.unpin(reason="Timed pin expired")
+                await channel.send(
+                    f"\N{PUSHPIN} A temporarily pinned message has been automatically unpinned.",
+                    reference=message,
+                )
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            pass
+
+        self.bot.loop.create_task(self.update_current())
+
+
+class DispatchedTimedPin:
+    __slots__ = ("timed_pin", "task")
+
+    def __init__(self, timed_pin, task):
+        self.timed_pin = timed_pin
+        self.task = task
+
+
+async def setup(bot):
+    await bot.add_cog(Pins(bot))

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -54,12 +54,9 @@ class TimedPin:
 
 
 def can_pin():
-    """Check that the user is the thread owner or has the pin messages permission."""
+    """Check that the user has pin permission or is the thread owner."""
 
     async def predicate(ctx):
-        if not isinstance(ctx.channel, discord.Thread):
-            raise commands.CheckFailure("This command can only be used in threads.")
-
         perms = ctx.channel.permissions_for(ctx.author)
 
         # Users with pin_messages (or manage_messages) can always pin
@@ -67,10 +64,10 @@ def can_pin():
             return True
 
         # Thread owner can pin in their own thread
-        if ctx.channel.owner_id == ctx.author.id:
+        if isinstance(ctx.channel, discord.Thread) and ctx.channel.owner_id == ctx.author.id:
             return True
 
-        raise commands.CheckFailure("You must be the thread owner or have the Pin Messages permission to use this.")
+        raise commands.CheckFailure("You must have the Pin Messages permission to use this.")
 
     return commands.check(predicate)
 
@@ -90,7 +87,7 @@ class PinIndexOrMessage(commands.Converter):
 
 
 class Pins(commands.Cog):
-    """For pinning and unpinning messages in threads."""
+    """For pinning and unpinning messages."""
 
     def __init__(self, bot):
         self.bot = bot
@@ -159,7 +156,7 @@ class Pins(commands.Cog):
     @commands.guild_only()
     @can_pin()
     async def pin(self, ctx, *, args: Optional[str] = None):
-        """Toggles a pin on a message in the current thread.
+        """Toggles a pin on a message.
 
         If the message is not pinned, it will be pinned. If it is already pinned, it will be unpinned.
 

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -53,16 +53,6 @@ class TimedPin:
         return self.expires_at - self.created_at
 
 
-class PinFlags(commands.FlagConverter, prefix="--", delimiter=" "):
-    duration: Optional[time.FutureTime] = commands.flag(
-        name="duration",
-        aliases=("d", "for", "in", "time", "t"),
-        description="Duration to keep the message pinned before auto-unpinning",
-        max_args=1,
-        default=None,
-    )
-
-
 def can_pin():
     """Check that the user is the thread owner or has manage_messages permission."""
 
@@ -119,22 +109,66 @@ class Pins(commands.Cog):
 
         raise commands.BadArgument("Please reply to a message or provide a message link/ID.")
 
+    async def parse_message_and_duration(self, ctx, args: Optional[str] = None):
+        """Parse the combined message + duration arguments.
+
+        Supports:
+        - ?pin (reply, no duration)
+        - ?pin <message> (no duration)
+        - ?pin <duration> (reply, with duration)
+        - ?pin <message> <duration>
+        """
+
+        if args is None:
+            return await self.resolve_message(ctx), None
+
+        parts = args.split(None, 1)
+        first = parts[0]
+
+        # Try to resolve the first part as a message
+        msg = None
+        try:
+            msg = await commands.MessageConverter().convert(ctx, first)
+        except commands.MessageNotFound:
+            pass
+
+        if msg is not None:
+            # First part is a message, rest (if any) is duration
+            duration_str = parts[1] if len(parts) > 1 else None
+            if duration_str is not None:
+                try:
+                    duration = time.FutureTime(duration_str, now=ctx.message.created_at)
+                except commands.BadArgument:
+                    raise commands.BadArgument(f"Invalid duration: `{duration_str}`")
+                return msg, duration
+            return msg, None
+
+        # First part is not a message, try the whole thing as a duration (user is replying)
+        try:
+            duration = time.FutureTime(args, now=ctx.message.created_at)
+        except commands.BadArgument:
+            raise commands.BadArgument(
+                f"Could not find a message matching `{first}`. Please reply to a message or provide a valid message link/ID."
+            )
+
+        return await self.resolve_message(ctx), duration
+
     @commands.group(invoke_without_command=True)
     @commands.guild_only()
     @can_pin()
-    async def pin(self, ctx, message: Optional[str] = None, *, flags: PinFlags):
+    async def pin(self, ctx, *, args: Optional[str] = None):
         """Toggles a pin on a message in the current thread.
 
         If the message is not pinned, it will be pinned. If it is already pinned, it will be unpinned.
 
         You can reply to the message, or pass a message link/ID.
 
-        Use --duration to pin temporarily, e.g.:
-        \u2022 ?pin <message> --duration 2h
-        \u2022 ?pin --duration 30m (when replying)
+        Optionally provide a duration to pin temporarily, e.g.:
+        \u2022 ?pin <message> 2h
+        \u2022 ?pin 30m (when replying)
         """
 
-        target = await self.resolve_message(ctx, message)
+        target, duration = await self.parse_message_and_duration(ctx, args)
 
         if target.pinned:
             # Unpin the message (toggle off)
@@ -155,14 +189,14 @@ class Pins(commands.Cog):
         # Pin the message (toggle on)
         await target.pin(reason=f"Pinned by {ctx.author} (ID: {ctx.author.id})")
 
-        if flags.duration is not None:
+        if duration is not None:
             timed_pin = TimedPin(
                 user_id=ctx.author.id,
                 guild_id=ctx.guild.id,
                 channel_id=ctx.channel.id,
                 message_id=target.id,
                 created_at=ctx.message.created_at,
-                expires_at=flags.duration.dt,
+                expires_at=duration.dt,
             )
 
             id = await self.bot.mongo.reserve_id("timed_pin")
@@ -172,7 +206,7 @@ class Pins(commands.Cog):
             self.bot.loop.create_task(self.update_current(timed_pin))
 
             await ctx.send(
-                f"\N{PUSHPIN} Pinned! This message will be automatically unpinned {format_dt(flags.duration.dt, 'R')}."
+                f"\N{PUSHPIN} Pinned! This message will be automatically unpinned {format_dt(duration.dt, 'R')}."
             )
         else:
             await ctx.send("\N{PUSHPIN} Pinned!")


### PR DESCRIPTION
## Summary

Adds a new `?pin` command group that lets users with the Pin Messages permission (or Manage Messages) pin and unpin messages in any channel. In threads, the thread owner can also use the command without needing explicit pin permission. Messages can be targeted by replying or passing a message link/ID via `MessageConverter`.

**Commands:**
- `?pin [message] [duration]` — **Toggle**: pins the message if unpinned, unpins it if already pinned. Optional positional duration for temporary pins (e.g. `?pin <message> 2h`, `?pin 30m` when replying).
- `?pin list` — List all pinned messages with numbered indices (#1, #2, …) and count (X/250)
- `?pin view <#index | message>` — Show a specific pin's full content in an embed (with author name/icon, jump link, attachments). Accepts a `#index` from `?pin list` or a message link/ID.

**Temporary pins** are stored in MongoDB (`timed_pin` collection) and auto-unpin on expiry using the same dispatch pattern as the reminders cog.

## Updates since last revision

- **Pin limit updated to 250** (Discord increased this from 50 in August 2025). Added `MAX_PINS = 250` constant used in `PinIndexOrMessage` converter and `pin list` title.
- **`PIN_MESSAGES` permission handled via raw bit check** (`perms.value & (1 << 51)`) since the poketwo/discord.py fork (v2.3.2) does not expose `pin_messages` as an attribute. This replaces the previous `perms.pin_messages` call that would have raised `AttributeError`.
- **Works in any channel**, not just threads. Users with Pin Messages or Manage Messages can pin anywhere; thread owners get an additional allowance in their own threads.

## Review & Testing Checklist for Human

- [ ] **Custom argument parsing in `parse_message_and_duration` (highest risk)**: This method manually splits `args`, tries the first token as a `MessageConverter`, and falls back to treating the whole string as a `FutureTime` duration. Only `commands.MessageNotFound` is caught — other exceptions from `MessageConverter` (e.g. `ChannelNotFound`, generic `BadArgument`) will propagate as unhandled errors. Verify edge cases like malformed links, channel-message ID format, etc. **Not live-tested.**
- [ ] **`FutureTime` direct instantiation**: The code calls `time.FutureTime(duration_str, now=ctx.message.created_at)` directly rather than through a converter. Verify `FutureTime.__init__` supports this usage — the reminders cog may use it differently (as a type annotation converter). If `FutureTime` expects to be called via `convert()`, this will break at runtime.
- [ ] **`PIN_MESSAGES_BIT` raw permission check**: The `can_pin()` check uses `perms.value & (1 << 51)` to check the PIN_MESSAGES permission since the discord.py fork doesn't expose it as an attribute. Verify the bit position `1 << 51` matches the actual Discord API value and that `perms.value` correctly includes this bit from the gateway/API responses despite the library not knowing about it.
- [ ] **Toggle + duration interaction**: When toggling off (unpinning), any provided duration is silently ignored. Verify this is acceptable UX — user might expect an error or warning if they pass a duration on an already-pinned message (e.g. `?pin <pinned-msg> 2h`).
- [ ] **PinIndexOrMessage converter**: Numbers 1–250 are always interpreted as pin indices, not message IDs. This is fine in practice (real message IDs are snowflakes), but worth being aware of.

**Suggested test plan:** Deploy to a test bot and verify:
1. Pin via reply: `?pin` (replying to a message) — in a thread and in a regular channel
2. Pin via message link/ID: `?pin <link>`
3. Pin with duration via reply: `?pin 30m` (replying)
4. Pin with duration via link: `?pin <link> 2h`
5. Toggle: pin the same message again → should unpin
6. Temp pin with `?pin <msg> 30s` → wait for auto-unpin notification
7. Manually unpin (toggle off) a temp pin, then create another temp pin → verify dispatch fires correctly
8. `?pin list` shows numbered indices and correct count out of 250
9. `?pin view #1` and `?pin view <message_link>` show correct embed
10. User with Pin Messages perm (but not Manage Messages) can use `?pin` in a regular channel
11. Thread owner without any pin perm succeeds in their thread
12. User without pin perm in a non-thread channel gets denied
13. Edge: `?pin` with no reply and no args → should show helpful error

### Notes
- New MongoDB collection `timed_pin` is created implicitly (no migration needed)
- No `cog_unload`: timed pin dispatch task is not cancelled on cog unload/reload, consistent with the reminders cog
- `DispatchedTimedPin` is a plain class with `__slots__` rather than a `NamedTuple` (reminders uses `NamedTuple`) — functionally equivalent, just a style difference
- `pin list` and `pin view` have no pin-permission restriction — any guild member can view pinned messages
- `PIN_MESSAGES_BIT = 1 << 51` and `MAX_PINS = 250` are defined as module-level constants — easy to update when the discord.py fork adds native support or if Discord changes limits

Link to Devin session: https://app.devin.ai/sessions/82e7a1d7761c4b70bf9117d229a26929
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
