### PR TITLE
Require Moderator role for lock/unlock commands

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1150,13 +1150,13 @@ class Moderation(commands.Cog):
 
     @commands.hybrid_command()
     @commands.guild_only()
-    @checks.is_trial_moderator()
+    @checks.is_moderator()
     async def lock(self, ctx, channel: Optional[discord.TextChannel] = None, *, reason: Optional[str] = None):
         """Locks a channel by preventing members from sending messages.
 
         If no channel is provided, locks the current channel.
 
-        You must have the Trial Moderator role to use this.
+        You must have the Moderator role to use this.
         """
 
         channel = channel or ctx.channel
@@ -1178,13 +1178,13 @@ class Moderation(commands.Cog):
 
     @commands.hybrid_command()
     @commands.guild_only()
-    @checks.is_trial_moderator()
+    @checks.is_moderator()
     async def unlock(self, ctx, channel: Optional[discord.TextChannel] = None, *, reason: Optional[str] = None):
         """Unlocks a channel by allowing members to send messages again.
 
         If no channel is provided, unlocks the current channel.
 
-        You must have the Trial Moderator role to use this.
+        You must have the Moderator role to use this.
         """
 
         channel = channel or ctx.channel


### PR DESCRIPTION
## Summary

Raises the minimum role requirement for the `lock` and `unlock` commands from Trial Moderator to Moderator. Updates both the `@checks` decorator and the docstring on each command.

## Review & Testing Checklist for Human

- [x] Confirm `is_moderator()` is the intended minimum role. Per `helpers/constants.py`, `MODERATOR_ROLES` includes Community Manager roles plus IDs `724879492622843944` and `930346843521556540` — verify these map to the correct Moderator roles on the server.
- [x] Test in Discord: a Trial Moderator should be **denied**, and a Moderator should be **allowed** to run both `/lock` and `/unlock`.

### Notes
- No functional logic changes — only the permission gate and its corresponding docstring were updated.

Link to Devin session: https://app.devin.ai/sessions/1ad99aced4dd4bd5b3328b50fc72b1a3
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
