### PR TITLE
Add AFK status management cog (supersedes #67)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,6 +16,7 @@ ESSENTIAL_COGS = [
 ]
 
 COGS = [
+    "afk",
     "automod",
     "autopost",
     "auto_lock_threads",

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -68,7 +68,7 @@ class Afk(commands.Cog):
         if len(status) > CHAR_LIMIT:
             return await ctx.send(f"Status too long (max {CHAR_LIMIT} characters).")
 
-        user = await self.bot.mongo.db.member.find_one_and_update(
+        await self.bot.mongo.db.member.update_one(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
             {"$set": {"afk": True, "status": status, "since": int(datetime.utcnow().timestamp())}},
             upsert=True,
@@ -79,7 +79,7 @@ class Afk(commands.Cog):
     @commands.guild_only()
     async def clear(self, ctx):
         """Reset your status"""
-        user = await self.bot.mongo.db.member.find_one_and_update(
+        await self.bot.mongo.db.member.update_one(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
             {"$set": {"afk": False, "status": "Online", "since": 0}},
             upsert=True,
@@ -94,7 +94,7 @@ class Afk(commands.Cog):
 
         You must have the Community Manager role to use this."""
 
-        user = await self.bot.mongo.db.member.find_one_and_update(
+        await self.bot.mongo.db.member.update_one(
             {"_id": {"id": member.id, "guild_id": ctx.guild.id}},
             {"$set": {"afk": False, "status": "Online", "since": 0}},
             upsert=True,

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -8,6 +8,8 @@ from discord.ext.menus.views import ViewMenuPages
 from helpers.pagination import AsyncEmbedFieldsPageSource
 from helpers import checks
 
+MAX = 75 
+
 class Afk(commands.Cog):
     """For AFK status"""
 
@@ -64,8 +66,8 @@ class Afk(commands.Cog):
     async def afk(self, ctx, *, status: Optional[str] = "AFK"):
         """Set your status to AFK"""
 
-        if len(status) > 75:
-            return await ctx.send("Status too long (max 75 characters).")
+        if len(status) > MAX:
+            return await ctx.send(f"Status too long (max {MAX} characters).")
 
         user = await self.bot.mongo.db.member.find_one_and_update(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -41,15 +41,15 @@ class Afk(commands.Cog):
         if message.content.startswith(tuple(self.bot.command_prefix)):
             return
 
-#        Currently disable may affect Bot's performance      
-#        status, _, _= await self.get_status(message.author)
-#        if status == Status.AFK.value:
-#            await self.bot.mongo.db.member.update_one(
-#                {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
-#                {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
-#                upsert=True,
-#            )
-#            await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
+        Currently disable may affect Bot's performance      
+        status, _, _= await self.get_status(message.author)
+        if status == Status.AFK.value:
+            await self.bot.mongo.db.member.update_one(
+                {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
+                {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
+                upsert=True,
+            )
+            await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
 
         if not message.mentions:
             return
@@ -64,7 +64,7 @@ class Afk(commands.Cog):
                 except discord.Forbidden:
                     pass # User unavailable.
                     
-            elif status == Status.DND:
+            elif status == Status.DND.value:
                 await message.channel.send(f"User **{member.name}** is currently `{reason}` and on **Do Not Disturb**.")
 
     @commands.hybrid_group(fallback="set")
@@ -140,9 +140,9 @@ class Afk(commands.Cog):
         embed = discord.Embed(color=discord.Color.blurple())
         embed.set_author(name=member.display_name, icon_url=member.display_avatar.url)
         if status != Status.ONLINE.value:
-            embed.add_field(name=status.value, value=f"{reason} since <t:{since}:R>")
+            embed.add_field(name=status, value=f"{reason} since <t:{since}:R>")
         else:
-            embed.add_field(name=status.value, value="Online")
+            embed.add_field(name=status, value="Online")
         
         await ctx.send(embed=embed)
 

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -60,10 +60,10 @@ class Afk(commands.Cog):
                 except discord.Forbidden:
                     pass # User unavailable.
 
-    @commands.hybrid_command()
+    @commands.hybrid_group(fallback="set")
     @commands.guild_only()
     async def afk(self, ctx, *, status: Optional[str] = "AFK"):
-        """Set your status to AFK"""
+        """If no subcommand is called, set your status to AFK"""
 
         if len(status) > CHAR_LIMIT:
             return await ctx.send(f"Status too long (max {CHAR_LIMIT} characters).")
@@ -75,9 +75,9 @@ class Afk(commands.Cog):
         )
         await ctx.send(f"Set user **{ctx.author.name}** status to `{status}`.")
 
-    @commands.hybrid_command()
+    @afk.command()
     @commands.guild_only()
-    async def unafk(self, ctx):
+    async def clear(self, ctx):
         """Reset your status"""
         user = await self.bot.mongo.db.member.find_one_and_update(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
@@ -86,10 +86,10 @@ class Afk(commands.Cog):
         )
         await ctx.send(f"Status cleared for user **{ctx.author.name}**.")
 
-    @commands.hybrid_command()
+    @afk.command(aliases=("fr",))
     @commands.guild_only()
     @checks.is_server_admin()
-    async def resetstatus(self, ctx, member: discord.Member, note: Optional[str] = None):
+    async def forcereset(self, ctx, member: discord.Member, note: Optional[str] = None):
         """Resets user's status.
 
         You must have the Community Manager role to use this."""
@@ -107,7 +107,7 @@ class Afk(commands.Cog):
             except discord.Forbidden:
                 pass # User unavailable.
 
-    @commands.hybrid_command()
+    @afk.command()
     @commands.guild_only()
     async def status(self, ctx, *, member: Optional[discord.Member] = None):
         """Shows your current status."""

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 from enum import Enum
 
@@ -41,7 +41,6 @@ class Afk(commands.Cog):
         if message.content.startswith(tuple(self.bot.command_prefix)):
             return
 
-        Currently disable may affect Bot's performance      
         status, _, _= await self.get_status(message.author)
         if status == Status.AFK.value:
             await self.bot.mongo.db.member.update_one(
@@ -77,7 +76,7 @@ class Afk(commands.Cog):
         
         await self.bot.mongo.db.member.update_one(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"status": Status.AFK.value, "reason": reason, "since": int(datetime.utcnow().timestamp())}},
+            {"$set": {"status": Status.AFK.value, "reason": reason, "since": int(datetime.now(timezone.utc).timestamp())}},
             upsert=True,
         )
         await ctx.send(f"Set user **{ctx.author.name}** status to `{reason}`.")
@@ -92,7 +91,7 @@ class Afk(commands.Cog):
         
         await self.bot.mongo.db.member.update_one(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"status": Status.DND.value, "reason": reason, "since": int(datetime.utcnow().timestamp())}},
+            {"$set": {"status": Status.DND.value, "reason": reason, "since": int(datetime.now(timezone.utc).timestamp())}},
             upsert=True,
         )
         await ctx.send(f"Set user **{ctx.author.name}** status to `{reason}` and **Do Not Disturb**.")

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -38,7 +38,8 @@ class Afk(commands.Cog):
     async def on_message(self, message):
         if message.guild is None or message.author.bot:
             return
-        if message.content.startswith(tuple(self.bot.command_prefix)):
+        ctx = await self.bot.get_context(message)
+        if ctx.command is not None:
             return
 
         status, _, _ = await self.get_status(message.author)

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -88,7 +88,7 @@ class Afk(commands.Cog):
     @commands.hybrid_command()
     @commands.guild_only()
     @checks.is_server_admin()
-    async def resetstatus(self, ctx, member: discord.Member):
+    async def resetstatus(self, ctx, member: discord.Member, note: Optional[str] = None):
         """Resets user's status.
 
         You must have the Community Manager role to use this."""
@@ -99,6 +99,12 @@ class Afk(commands.Cog):
             upsert=True,
         )
         await ctx.send(f"Status force cleared for user **{member.name}**.")
+        
+        if note is not None:
+            try:
+                await member.send(f"Your status has been reset because {note}")
+            except discord.Forbidden:
+                pass # User unavailable.
 
     @commands.hybrid_command()
     @commands.guild_only()

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,5 +1,3 @@
-import contextlib
-import itertools
 from datetime import datetime
 from typing import Optional
 
@@ -12,22 +10,24 @@ from helpers import checks
 
 class Afk(commands.Cog):
     """For AFK status"""
-    
+
     def __init__(self, bot):
         self.bot = bot
-       
+
     async def get_status(self, member):
         member_data = await self.bot.mongo.db.member.find_one(
             {"_id": {"id": member.id, "guild_id": member.guild.id}}
         )
-        
+
         if not member_data:
-            return False, "Online"
-            
+            return False, "Online", 0
+
         afk = member_data.get("afk", False)
         status = member_data.get("status", "Online")
-        return afk, status
+        since = member_data.get("since", 0)
         
+        return afk, status, since
+
     @commands.Cog.listener()
     async def on_message(self, message):
         if message.guild is None or message.author.bot:
@@ -37,48 +37,50 @@ class Afk(commands.Cog):
             return
 
 #        Currently disable may affect Bot's performance      
-#        afk, _ = await self.get_status(message.author)
+#        afk, _, _= await self.get_status(message.author)
 #        if afk:
 #            await self.bot.mongo.db.member.find_one_and_update(
 #                {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
-#                {"$set": {"afk": False, "status": "Online"}},
+#                {"$set": {"afk": False, "status": "Online", "since": 0}},
 #                upsert=True,
 #            )
 #            await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
-        
+
         if not message.mentions:
             return
-       
+
         for member in set(message.mentions):
-            afk, status = await self.get_status(member)
+            afk, status, since = await self.get_status(member)
             if afk:
-                await message.channel.send(f"User **{member.name}** is currently `{status}`.")
-                
+                await message.channel.send(f"User **{member.name}** is currently `{status}` since <t:{since}:R>.")
+
                 try:
                     await member.send(f"You have been mentioned in {message.channel} while you were {status}.")
                 except discord.Forbidden:
                     pass # User unavailable.
-    
+
     @commands.hybrid_command()
+    @commands.guild_only()
     async def afk(self, ctx, *, status: Optional[str] = "AFK"):
         """Set your status to AFK"""
-        
-        if len(status) > 100:
-            return await ctx.send("Status too long (max 100 characters).")
-            
+
+        if len(status) > 75:
+            return await ctx.send("Status too long (max 75 characters).")
+
         user = await self.bot.mongo.db.member.find_one_and_update(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"afk": True, "status": f"{status} since <t:{int(datetime.utcnow().timestamp())}:R>"}},
+            {"$set": {"afk": True, "status": status, "since": int(datetime.utcnow().timestamp())}},
             upsert=True,
         )
         await ctx.send(f"Set user **{ctx.author.name}** status to `{status}`.")
 
     @commands.hybrid_command()
+    @commands.guild_only()
     async def unafk(self, ctx):
         """Reset your status"""
         user = await self.bot.mongo.db.member.find_one_and_update(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"afk": False, "status": "Online"}},
+            {"$set": {"afk": False, "status": "Online", "since": 0}},
             upsert=True,
         )
         await ctx.send(f"Status cleared for user **{ctx.author.name}**.")
@@ -90,26 +92,30 @@ class Afk(commands.Cog):
         """Resets user's status.
 
         You must have the Community Manager role to use this."""
-        
+
         user = await self.bot.mongo.db.member.find_one_and_update(
             {"_id": {"id": member.id, "guild_id": ctx.guild.id}},
-            {"$set": {"afk": False, "status": "Online"}},
+            {"$set": {"afk": False, "status": "Online", "since": 0}},
             upsert=True,
         )
         await ctx.send(f"Status force cleared for user **{member.name}**.")
- 
+
     @commands.hybrid_command()
+    @commands.guild_only()
     async def status(self, ctx, *, member: Optional[discord.Member] = None):
         """Shows your current status."""
         if member is None:
             member = ctx.author
-        afk, status = await self.get_status(member)
+        afk, status, since = await self.get_status(member)
 
         embed = discord.Embed(color=discord.Color.blurple())
         embed.set_author(name=member.display_name, icon_url=member.display_avatar.url)
-        embed.add_field(name="Status", value=f"{status}")
+        if afk:
+            embed.add_field(name="Status", value=f"{status} since <t:{since}:R>")
+        else:
+            embed.add_field(name="Status", value="Online")
 
         await ctx.send(embed=embed)
- 
+
 async def setup(bot):
     await bot.add_cog(Afk(bot))

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -41,7 +41,7 @@ class Afk(commands.Cog):
         if message.content.startswith(tuple(self.bot.command_prefix)):
             return
 
-        status, _, _= await self.get_status(message.author)
+        status, _, _ = await self.get_status(message.author)
         if status == Status.AFK.value:
             await self.bot.mongo.db.member.update_one(
                 {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
@@ -111,7 +111,7 @@ class Afk(commands.Cog):
     @afk.command(aliases=("fr",))
     @commands.guild_only()
     @checks.is_server_admin()
-    async def forcereset(self, ctx, member: discord.Member, note: Optional[str] = None):
+    async def forcereset(self, ctx, member: discord.Member, *, note: Optional[str] = None):
         """Resets user's status.
 
         You must have the Community Manager role to use this."""

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -8,7 +8,7 @@ from discord.ext.menus.views import ViewMenuPages
 from helpers.pagination import AsyncEmbedFieldsPageSource
 from helpers import checks
 
-MAX = 75 
+CHAR_LIMIT = 75 
 
 class Afk(commands.Cog):
     """For AFK status"""
@@ -66,8 +66,8 @@ class Afk(commands.Cog):
     async def afk(self, ctx, *, status: Optional[str] = "AFK"):
         """Set your status to AFK"""
 
-        if len(status) > MAX:
-            return await ctx.send(f"Status too long (max {MAX} characters).")
+        if len(status) > CHAR_LIMIT:
+            return await ctx.send(f"Status too long (max {CHAR_LIMIT} characters).")
 
         user = await self.bot.mongo.db.member.find_one_and_update(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,0 +1,110 @@
+import contextlib
+import itertools
+from datetime import datetime
+from typing import Optional
+
+import discord
+from discord.ext import commands
+from discord.ext.menus.views import ViewMenuPages
+
+from helpers.pagination import AsyncEmbedFieldsPageSource
+from helpers import checks
+
+class Afk(commands.Cog):
+    """For AFK status"""
+    
+    def __init__(self, bot):
+        self.bot = bot
+       
+    async def get_status(self, member):
+        member_data = await self.bot.mongo.db.member.find_one(
+            {"_id": {"id": member.id, "guild_id": member.guild.id}}
+        )
+        
+        if not member_data:
+            return False, "Online"
+            
+        afk = member_data.get("afk", False)
+        status = member_data.get("status", "Online")
+        return afk, status
+        
+    @commands.Cog.listener()
+    async def on_message(self, message):
+        if message.guild is None or message.author.bot:
+            return
+        ctx = await self.bot.get_context(message)
+        if ctx.command is not None:
+            return
+
+#        Currently disable may affect Bot's performance      
+#        afk, _ = await self.get_status(message.author)
+#        if afk:
+#            await self.bot.mongo.db.member.find_one_and_update(
+#                {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
+#                {"$set": {"afk": False, "status": "Online"}},
+#                upsert=True,
+#            )
+#            await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
+        
+        if not message.mentions:
+            return
+       
+        for member in set(message.mentions):
+            afk, status = await self.get_status(member)
+            if afk:
+                await message.channel.send(f"User **{member.name}** is currently `{status}`.")
+    
+    @commands.hybrid_command()
+    async def afk(self, ctx, *, status: Optional[str] = "AFK"):
+        """Set your status to AFK"""
+        
+        if len(status) > 100:
+            return await ctx.send("Status too long (max 100 characters).")
+            
+        user = await self.bot.mongo.db.member.find_one_and_update(
+            {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
+            {"$set": {"afk": True, "status": f"{status} since <t:{int(datetime.utcnow().timestamp())}:R>"}},
+            upsert=True,
+        )
+        await ctx.send(f"Set user **{ctx.author.name}** status to `{status}`.")
+
+    @commands.hybrid_command()
+    async def unafk(self, ctx):
+        """Reset your status"""
+        user = await self.bot.mongo.db.member.find_one_and_update(
+            {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
+            {"$set": {"afk": False, "status": "Online"}},
+            upsert=True,
+        )
+        await ctx.send(f"Status cleared for user **{ctx.author.name}**.")
+
+    @commands.hybrid_command()
+    @commands.guild_only()
+    @checks.is_server_admin()
+    async def resetstatus(self, ctx, member: discord.Member):
+        """Resets user's status.
+
+        You must have the Community Manager role to use this."""
+        
+        user = await self.bot.mongo.db.member.find_one_and_update(
+            {"_id": {"id": member.id, "guild_id": ctx.guild.id}},
+            {"$set": {"afk": False, "status": "Online"}},
+            upsert=True,
+        )
+        await ctx.send(f"Status force cleared for user **{member.name}**.")
+ 
+    @commands.hybrid_command()
+    async def status(self, ctx, *, member: Optional[discord.Member] = None):
+        """Shows your current status."""
+        if member is None:
+            member = ctx.author
+        afk, status = await self.get_status(member)
+
+        embed = discord.Embed(color=discord.Color.blurple())
+        embed.set_author(name=member.display_name, icon_url=member.display_avatar.url)
+        embed.add_field(name="Status", value=f"{status}")
+
+        await ctx.send(embed=embed)
+ 
+async def setup(bot):
+    await bot.add_cog(Afk(bot))

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -69,9 +69,6 @@ class Afk(commands.Cog):
             await self.clear_status(message.author.id, message.guild.id)
             await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
 
-        if not message.mentions:
-            return
-
         for member in message.mentions:
             info = await self.get_status(member)
             if info.status == Status.AFK:

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -8,7 +8,7 @@ from discord.ext.menus.views import ViewMenuPages
 from helpers.pagination import AsyncEmbedFieldsPageSource
 from helpers import checks
 
-CHAR_LIMIT = 75 
+CHAR_LIMIT = 75
 
 class Afk(commands.Cog):
     """For AFK status"""
@@ -34,8 +34,7 @@ class Afk(commands.Cog):
     async def on_message(self, message):
         if message.guild is None or message.author.bot:
             return
-        ctx = await self.bot.get_context(message)
-        if ctx.command is not None:
+        if message.content.startswith(tuple(self.bot.command_prefix)):
             return
 
 #        Currently disable may affect Bot's performance      

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,14 +1,18 @@
 from datetime import datetime
 from typing import Optional
+from enum import Enum
 
 import discord
 from discord.ext import commands
-from discord.ext.menus.views import ViewMenuPages
 
-from helpers.pagination import AsyncEmbedFieldsPageSource
 from helpers import checks
 
 CHAR_LIMIT = 75
+
+class Status(Enum):
+    AFK = "AFK"
+    ONLINE = "Online"
+    DND = "Do Not Disturb"
 
 class Afk(commands.Cog):
     """For AFK status"""
@@ -22,13 +26,13 @@ class Afk(commands.Cog):
         )
 
         if not member_data:
-            return False, "Online", 0
+            return Status.ONLINE.value, Status.ONLINE.value, 0
 
-        afk = member_data.get("afk", False)
-        status = member_data.get("status", "Online")
+        status = member_data.get("status", Status.ONLINE.value)
+        reason = member_data.get("reason", Status.ONLINE.value)
         since = member_data.get("since", 0)
         
-        return afk, status, since
+        return status, reason, since
 
     @commands.Cog.listener()
     async def on_message(self, message):
@@ -38,11 +42,11 @@ class Afk(commands.Cog):
             return
 
 #        Currently disable may affect Bot's performance      
-#        afk, _, _= await self.get_status(message.author)
-#        if afk:
-#            await self.bot.mongo.db.member.find_one_and_update(
+#        status, _, _= await self.get_status(message.author)
+#        if status == Status.AFK.value:
+#            await self.bot.mongo.db.member.update_one(
 #                {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
-#                {"$set": {"afk": False, "status": "Online", "since": 0}},
+#                {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
 #                upsert=True,
 #            )
 #            await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
@@ -51,29 +55,47 @@ class Afk(commands.Cog):
             return
 
         for member in set(message.mentions):
-            afk, status, since = await self.get_status(member)
-            if afk:
-                await message.channel.send(f"User **{member.name}** is currently `{status}` since <t:{since}:R>.")
-
+            status, reason, since = await self.get_status(member)
+            if status == Status.AFK.value:
+                await message.channel.send(f"User **{member.name}** is currently `{reason}` since <t:{since}:R>.")
+            
                 try:
-                    await member.send(f"You have been mentioned in {message.channel} while you were {status}.")
+                    await member.send(f"You have been mentioned in {message.channel} while you were {reason}.\n Jump To: {message.jump_url}")
                 except discord.Forbidden:
                     pass # User unavailable.
+                    
+            elif status == Status.DND:
+                await message.channel.send(f"User **{member.name}** is currently `{reason}` and on **Do Not Disturb**.")
 
     @commands.hybrid_group(fallback="set")
     @commands.guild_only()
-    async def afk(self, ctx, *, status: Optional[str] = "AFK"):
+    async def afk(self, ctx, *, reason: Optional[str] = Status.AFK.value):
         """If no subcommand is called, set your status to AFK"""
 
-        if len(status) > CHAR_LIMIT:
-            return await ctx.send(f"Status too long (max {CHAR_LIMIT} characters).")
-
+        if len(reason) > CHAR_LIMIT:
+            return await ctx.send(f"Reason too long (max {CHAR_LIMIT} characters).")
+        
         await self.bot.mongo.db.member.update_one(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"afk": True, "status": status, "since": int(datetime.utcnow().timestamp())}},
+            {"$set": {"status": Status.AFK.value, "reason": reason, "since": int(datetime.utcnow().timestamp())}},
             upsert=True,
         )
-        await ctx.send(f"Set user **{ctx.author.name}** status to `{status}`.")
+        await ctx.send(f"Set user **{ctx.author.name}** status to `{reason}`.")
+
+    @afk.command()
+    @commands.guild_only()
+    async def dnd(self, ctx, *, reason: Optional[str] = Status.DND.value):
+        """Set your status on Do Not Disturb"""
+        
+        if len(reason) > CHAR_LIMIT:
+            return await ctx.send(f"Reason too long (max {CHAR_LIMIT} characters).")
+        
+        await self.bot.mongo.db.member.update_one(
+            {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
+            {"$set": {"status": Status.DND.value, "reason": reason, "since": int(datetime.utcnow().timestamp())}},
+            upsert=True,
+        )
+        await ctx.send(f"Set user **{ctx.author.name}** status to `{reason}` and **Do Not Disturb**.")
 
     @afk.command()
     @commands.guild_only()
@@ -81,7 +103,7 @@ class Afk(commands.Cog):
         """Reset your status"""
         await self.bot.mongo.db.member.update_one(
             {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"afk": False, "status": "Online", "since": 0}},
+            {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
             upsert=True,
         )
         await ctx.send(f"Status cleared for user **{ctx.author.name}**.")
@@ -96,7 +118,7 @@ class Afk(commands.Cog):
 
         await self.bot.mongo.db.member.update_one(
             {"_id": {"id": member.id, "guild_id": ctx.guild.id}},
-            {"$set": {"afk": False, "status": "Online", "since": 0}},
+            {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
             upsert=True,
         )
         await ctx.send(f"Status force cleared for user **{member.name}**.")
@@ -113,15 +135,15 @@ class Afk(commands.Cog):
         """Shows your current status."""
         if member is None:
             member = ctx.author
-        afk, status, since = await self.get_status(member)
+        status, reason, since = await self.get_status(member)
 
         embed = discord.Embed(color=discord.Color.blurple())
         embed.set_author(name=member.display_name, icon_url=member.display_avatar.url)
-        if afk:
-            embed.add_field(name="Status", value=f"{status} since <t:{since}:R>")
+        if status != Status.ONLINE.value:
+            embed.add_field(name=status.value, value=f"{reason} since <t:{since}:R>")
         else:
-            embed.add_field(name="Status", value="Online")
-
+            embed.add_field(name=status.value, value="Online")
+        
         await ctx.send(embed=embed)
 
 async def setup(bot):

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -26,12 +26,12 @@ class Afk(commands.Cog):
         )
 
         if not member_data:
-            return Status.ONLINE.value, Status.ONLINE.value, 0
+            return Status.ONLINE, Status.ONLINE.value, 0
 
-        status = member_data.get("status", Status.ONLINE.value)
+        status = Status(member_data.get("status", Status.ONLINE.value))
         reason = member_data.get("reason", Status.ONLINE.value)
         since = member_data.get("since", 0)
-        
+
         return status, reason, since
 
     @commands.Cog.listener()
@@ -43,7 +43,7 @@ class Afk(commands.Cog):
             return
 
         status, _, _ = await self.get_status(message.author)
-        if status == Status.AFK.value:
+        if status == Status.AFK:
             await self.bot.mongo.db.member.update_one(
                 {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
                 {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
@@ -56,7 +56,7 @@ class Afk(commands.Cog):
 
         for member in set(message.mentions):
             status, reason, since = await self.get_status(member)
-            if status == Status.AFK.value:
+            if status == Status.AFK:
                 await message.channel.send(f"User **{member.name}** is currently `{reason}` since <t:{since}:R>.")
                 
                 if message.channel.permissions_for(member).view_channel:
@@ -65,7 +65,7 @@ class Afk(commands.Cog):
                     except discord.Forbidden:
                         pass # User unavailable.
                     
-            elif status == Status.DND.value:
+            elif status == Status.DND:
                 await message.channel.send(f"User **{member.name}** is currently `{reason}` and on **Do Not Disturb**.")
 
     @commands.hybrid_group(fallback="set")
@@ -140,10 +140,10 @@ class Afk(commands.Cog):
 
         embed = discord.Embed(color=discord.Color.blurple())
         embed.set_author(name=member.display_name, icon_url=member.display_avatar.url)
-        if status != Status.ONLINE.value:
-            embed.add_field(name=status, value=f"{reason} since <t:{since}:R>")
+        if status != Status.ONLINE:
+            embed.add_field(name=status.value, value=f"{reason} since <t:{since}:R>")
         else:
-            embed.add_field(name=status, value="Online")
+            embed.add_field(name=status.value, value="Online")
         
         await ctx.send(embed=embed)
 

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -70,6 +70,8 @@ class Afk(commands.Cog):
             await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
 
         for member in message.mentions:
+            if member.id == message.author.id:
+                continue
             info = await self.get_status(member)
             if info.status == Status.AFK:
                 await message.channel.send(

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -72,7 +72,7 @@ class Afk(commands.Cog):
         if not message.mentions:
             return
 
-        for member in set(message.mentions):
+        for member in message.mentions:
             info = await self.get_status(member)
             if info.status == Status.AFK:
                 await message.channel.send(

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -57,11 +57,12 @@ class Afk(commands.Cog):
             status, reason, since = await self.get_status(member)
             if status == Status.AFK.value:
                 await message.channel.send(f"User **{member.name}** is currently `{reason}` since <t:{since}:R>.")
-            
-                try:
-                    await member.send(f"You have been mentioned in {message.channel} while you were {reason}.\n Jump To: {message.jump_url}")
-                except discord.Forbidden:
-                    pass # User unavailable.
+                
+                if message.channel.permissions_for(member).view_channel:
+                    try:
+                        await member.send(f"You have been mentioned in {message.channel} while you were {reason}.\n Jump To: {message.jump_url}")
+                    except discord.Forbidden:
+                        pass # User unavailable.
                     
             elif status == Status.DND.value:
                 await message.channel.send(f"User **{member.name}** is currently `{reason}` and on **Do Not Disturb**.")

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
-from typing import Optional
 from enum import Enum
+from typing import NamedTuple, Optional
 
 import discord
 from discord.ext import commands
@@ -9,143 +9,153 @@ from helpers import checks
 
 CHAR_LIMIT = 75
 
+
 class Status(Enum):
     AFK = "AFK"
     ONLINE = "Online"
     DND = "Do Not Disturb"
 
+
+class MemberStatus(NamedTuple):
+    status: Status
+    reason: str
+    since: int
+
+
 class Afk(commands.Cog):
     """For AFK status"""
 
-    def __init__(self, bot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
 
-    async def get_status(self, member):
+    async def get_status(self, member: discord.Member) -> MemberStatus:
         member_data = await self.bot.mongo.db.member.find_one(
             {"_id": {"id": member.id, "guild_id": member.guild.id}}
         )
 
         if not member_data:
-            return Status.ONLINE, Status.ONLINE.value, 0
+            return MemberStatus(Status.ONLINE, Status.ONLINE.value, 0)
 
-        status = Status(member_data.get("status", Status.ONLINE.value))
-        reason = member_data.get("reason", Status.ONLINE.value)
-        since = member_data.get("since", 0)
+        return MemberStatus(
+            status=Status(member_data.get("status", Status.ONLINE.value)),
+            reason=member_data.get("reason", Status.ONLINE.value),
+            since=member_data.get("since", 0),
+        )
 
-        return status, reason, since
+    async def set_status(self, member_id: int, guild_id: int, status: Status, reason: str) -> None:
+        await self.bot.mongo.db.member.update_one(
+            {"_id": {"id": member_id, "guild_id": guild_id}},
+            {"$set": {"status": status.value, "reason": reason, "since": int(datetime.now(timezone.utc).timestamp())}},
+            upsert=True,
+        )
+
+    async def clear_status(self, member_id: int, guild_id: int) -> None:
+        await self.bot.mongo.db.member.update_one(
+            {"_id": {"id": member_id, "guild_id": guild_id}},
+            {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
+            upsert=True,
+        )
 
     @commands.Cog.listener()
-    async def on_message(self, message):
+    async def on_message(self, message: discord.Message):
         if message.guild is None or message.author.bot:
             return
         ctx = await self.bot.get_context(message)
         if ctx.command is not None:
             return
 
-        status, _, _ = await self.get_status(message.author)
-        if status == Status.AFK:
-            await self.bot.mongo.db.member.update_one(
-                {"_id": {"id": message.author.id, "guild_id": message.guild.id}},
-                {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
-                upsert=True,
-            )
+        info = await self.get_status(message.author)
+        if info.status == Status.AFK:
+            await self.clear_status(message.author.id, message.guild.id)
             await message.channel.send(f"Welcome back **{message.author.name}**, your AFK status has been removed.")
 
         if not message.mentions:
             return
 
         for member in set(message.mentions):
-            status, reason, since = await self.get_status(member)
-            if status == Status.AFK:
-                await message.channel.send(f"User **{member.name}** is currently `{reason}` since <t:{since}:R>.")
-                
+            info = await self.get_status(member)
+            if info.status == Status.AFK:
+                await message.channel.send(
+                    f"User **{member.name}** is currently `{info.reason}` since <t:{info.since}:R>."
+                )
                 if message.channel.permissions_for(member).view_channel:
                     try:
-                        await member.send(f"You have been mentioned in {message.channel} while you were {reason}.\n Jump To: {message.jump_url}")
+                        await member.send(
+                            f"You have been mentioned in {message.channel} while you were {info.reason}.\n"
+                            f"Jump To: {message.jump_url}"
+                        )
                     except discord.Forbidden:
-                        pass # User unavailable.
-                    
-            elif status == Status.DND:
-                await message.channel.send(f"User **{member.name}** is currently `{reason}` and on **Do Not Disturb**.")
+                        pass
+            elif info.status == Status.DND:
+                await message.channel.send(
+                    f"User **{member.name}** is currently `{info.reason}` and on **Do Not Disturb**."
+                )
 
     @commands.hybrid_group(fallback="set")
     @commands.guild_only()
-    async def afk(self, ctx, *, reason: Optional[str] = Status.AFK.value):
+    async def afk(self, ctx: commands.Context, *, reason: Optional[str] = Status.AFK.value):
         """If no subcommand is called, set your status to AFK"""
 
         if len(reason) > CHAR_LIMIT:
             return await ctx.send(f"Reason too long (max {CHAR_LIMIT} characters).")
-        
-        await self.bot.mongo.db.member.update_one(
-            {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"status": Status.AFK.value, "reason": reason, "since": int(datetime.now(timezone.utc).timestamp())}},
-            upsert=True,
-        )
+
+        await self.set_status(ctx.author.id, ctx.guild.id, Status.AFK, reason)
         await ctx.send(f"Set user **{ctx.author.name}** status to `{reason}`.")
 
     @afk.command()
     @commands.guild_only()
-    async def dnd(self, ctx, *, reason: Optional[str] = Status.DND.value):
+    async def dnd(self, ctx: commands.Context, *, reason: Optional[str] = Status.DND.value):
         """Set your status on Do Not Disturb"""
-        
+
         if len(reason) > CHAR_LIMIT:
             return await ctx.send(f"Reason too long (max {CHAR_LIMIT} characters).")
-        
-        await self.bot.mongo.db.member.update_one(
-            {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"status": Status.DND.value, "reason": reason, "since": int(datetime.now(timezone.utc).timestamp())}},
-            upsert=True,
-        )
+
+        await self.set_status(ctx.author.id, ctx.guild.id, Status.DND, reason)
         await ctx.send(f"Set user **{ctx.author.name}** status to `{reason}` and **Do Not Disturb**.")
 
     @afk.command()
     @commands.guild_only()
-    async def clear(self, ctx):
+    async def clear(self, ctx: commands.Context):
         """Reset your status"""
-        await self.bot.mongo.db.member.update_one(
-            {"_id": {"id": ctx.author.id, "guild_id": ctx.guild.id}},
-            {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
-            upsert=True,
-        )
+
+        await self.clear_status(ctx.author.id, ctx.guild.id)
         await ctx.send(f"Status cleared for user **{ctx.author.name}**.")
 
     @afk.command(aliases=("fr",))
     @commands.guild_only()
     @checks.is_server_admin()
-    async def forcereset(self, ctx, member: discord.Member, *, note: Optional[str] = None):
+    async def forcereset(self, ctx: commands.Context, member: discord.Member, *, note: Optional[str] = None):
         """Resets user's status.
 
         You must have the Community Manager role to use this."""
 
-        await self.bot.mongo.db.member.update_one(
-            {"_id": {"id": member.id, "guild_id": ctx.guild.id}},
-            {"$set": {"status": Status.ONLINE.value, "reason": Status.ONLINE.value, "since": 0}},
-            upsert=True,
-        )
+        await self.clear_status(member.id, ctx.guild.id)
         await ctx.send(f"Status force cleared for user **{member.name}**.")
-        
+
         if note is not None:
             try:
                 await member.send(f"Your status has been reset because {note}")
             except discord.Forbidden:
-                pass # User unavailable.
+                pass
 
     @afk.command()
     @commands.guild_only()
-    async def status(self, ctx, *, member: Optional[discord.Member] = None):
+    async def status(self, ctx: commands.Context, *, member: Optional[discord.Member] = None):
         """Shows your current status."""
+
         if member is None:
             member = ctx.author
-        status, reason, since = await self.get_status(member)
+        info = await self.get_status(member)
 
         embed = discord.Embed(color=discord.Color.blurple())
         embed.set_author(name=member.display_name, icon_url=member.display_avatar.url)
-        if status != Status.ONLINE:
-            embed.add_field(name=status.value, value=f"{reason} since <t:{since}:R>")
+        if info.status != Status.ONLINE:
+            embed.add_field(name=info.status.value, value=f"{info.reason} since <t:{info.since}:R>")
         else:
-            embed.add_field(name=status.value, value="Online")
-        
+            embed.add_field(name=info.status.value, value="Online")
+
         await ctx.send(embed=embed)
 
-async def setup(bot):
+
+async def setup(bot: commands.Bot):
     await bot.add_cog(Afk(bot))

--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -53,6 +53,11 @@ class Afk(commands.Cog):
             afk, status = await self.get_status(member)
             if afk:
                 await message.channel.send(f"User **{member.name}** is currently `{status}`.")
+                
+                try:
+                    await member.send(f"You have been mentioned in {message.channel} while you were {status}.")
+                except discord.Forbidden:
+                    pass # User unavailable.
     
     @commands.hybrid_command()
     async def afk(self, ctx, *, status: Optional[str] = "AFK"):


### PR DESCRIPTION
## Summary

Adds a new AFK status management cog (`cogs/afk.py`) based on PR #67 by TeamSammyUtilities, with all review feedback addressed and code cleaned up. This PR supersedes #67 (the original was from a fork).

**Features:**
- `?afk [reason]` — set AFK status (hybrid group command with `set` fallback)
- `?afk dnd [reason]` — set Do Not Disturb status
- `?afk clear` — clear your status
- `?afk forcereset <member> [note]` — admin-only force reset (aliased as `?afk fr`)
- `?afk status [member]` — view AFK status embed
- Auto-unafk: when an AFK user sends a non-command message, their status is automatically cleared
- Mention notifications: when a mentioned user is AFK/DND, the channel is notified and (for AFK) the user gets a DM with a jump link

**Fixes applied on top of #67:**
- Added `*` keyword-only marker to `forcereset`'s `note` parameter so multi-word notes are captured (was silently truncating to first word)
- Switched back to `get_context()` in `on_message` (instead of prefix check) per reviewer feedback, matching the pattern in `cogs/levels.py`

**Code cleanup (latest revision):**
- Added `MemberStatus` NamedTuple for `get_status` return type — replaces fragile positional tuple unpacking with named fields (`info.status`, `info.reason`, `info.since`)
- Added type hints to all methods (`member: discord.Member`, `ctx: commands.Context`, return types)
- Extracted `set_status()` and `clear_status()` helpers to eliminate repeated DB update logic across `afk`, `dnd`, `clear`, `forcereset`, and `on_message`
- Idiomatic enum comparisons (`info.status == Status.AFK` instead of `== Status.AFK.value`)
- Fixed trailing whitespace, broke long f-strings into multi-line

**Previously addressed review feedback from #67** (by WitherredAway):
- Restructured as `hybrid_group` with subcommands instead of top-level commands
- Switched from `find_one_and_update` to `update_one`
- Uncommented auto-unafk behavior
- Extracted char limit to `CHAR_LIMIT` constant
- Added `Status` enum for status strings

## Review & Testing Checklist for Human

- [ ] **DB field collision**: This writes `status`, `reason`, and `since` fields to the `member` collection. Verify no other cogs use these same field names on member documents — a collision would silently corrupt data.
- [ ] **Invalid status in DB**: `get_status()` calls `Status(value)` which will raise `ValueError` if the DB contains an unexpected string. Consider whether this needs defensive handling.
- [ ] **Per-message performance**: `on_message` calls both `get_context()` and `get_status()` (a `find_one` query) for every non-bot guild message. Confirm this is acceptable at the server's message volume.
- [ ] **DND auto-clear behavior**: AFK auto-clears when the user sends a message, but DND does not. Verify this asymmetry is intentional.
- [ ] **Test the bot end-to-end**: Deploy to a test environment and exercise the full flow — set AFK, send a message to auto-clear, mention an AFK user, use `?afk forcereset @user multi word note` to confirm multi-word notes work, check `?afk status`.

### Notes
- The cog has not been tested against a running bot instance — only syntax-verified via `py_compile`.

Link to Devin session: https://app.devin.ai/sessions/79fac9a2ae094ff58e6bc53a1775caae
Requested by: @oliver-ni
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/68" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
