### PR TITLE
feat: track lock state in MongoDB, support multi-channel lock/unlock

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1160,17 +1160,17 @@ class Moderation(commands.Cog):
         """
 
         channel = channel or ctx.channel
-        overwrites = channel.overwrites_for(ctx.guild.default_role)
 
+        channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
+        if channel_data and channel_data.get("locked", False):
+            return await ctx.send(f"{channel.mention} is already locked.", ephemeral=True)
+
+        overwrites = channel.overwrites_for(ctx.guild.default_role)
         if overwrites.send_messages is False:
             return await ctx.send(
                 f"{channel.mention} cannot be locked because @everyone already doesn't have access to chat there.",
                 ephemeral=True,
             )
-
-        channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
-        if channel_data and channel_data.get("locked", False):
-            return await ctx.send(f"{channel.mention} is already locked.", ephemeral=True)
 
         overwrites.send_messages = False
         audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
@@ -1198,10 +1198,13 @@ class Moderation(commands.Cog):
         channel = channel or ctx.channel
 
         channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
-        if not channel_data or not channel_data.get("locked", False):
+        is_locked_in_db = channel_data and channel_data.get("locked", False)
+        overwrites = channel.overwrites_for(ctx.guild.default_role)
+        is_locked_in_perms = overwrites.send_messages is False
+
+        if not is_locked_in_db and not is_locked_in_perms:
             return await ctx.send(f"{channel.mention} is not locked.", ephemeral=True)
 
-        overwrites = channel.overwrites_for(ctx.guild.default_role)
         overwrites.send_messages = None
         audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
         if reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1148,79 +1148,112 @@ class Moderation(commands.Cog):
         action = Action.build_from_mongo(self.bot, action)
         await ctx.send(embed=action.to_info_embed())
 
-    @commands.hybrid_command()
+    @commands.hybrid_group(invoke_without_command=True)
     @commands.guild_only()
     @checks.is_moderator()
-    async def lock(self, ctx, channel: Optional[discord.TextChannel] = None, *, reason: Optional[str] = None):
-        """Locks a channel by preventing members from sending messages.
+    async def lock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, reason: Optional[str] = None):
+        """Locks one or more channels by preventing members from sending messages.
 
         If no channel is provided, locks the current channel.
 
         You must have the Moderator role to use this.
         """
 
-        channel = channel or ctx.channel
+        if not channels:
+            channels = [ctx.channel]
 
-        channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
-        if channel_data and channel_data.get("locked", False):
-            return await ctx.send(f"{channel.mention} is already locked.", ephemeral=True)
+        results = []
+        for channel in channels:
+            channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
+            if channel_data and channel_data.get("locked", False):
+                results.append(f"{channel.mention} is already locked.")
+                continue
 
-        overwrites = channel.overwrites_for(ctx.guild.default_role)
-        if overwrites.send_messages is False:
-            return await ctx.send(
-                f"{channel.mention} cannot be locked because it was manually restricted.",
-                ephemeral=True,
-            )
+            overwrites = channel.overwrites_for(ctx.guild.default_role)
+            if overwrites.send_messages is False:
+                results.append(f"{channel.mention} cannot be locked because it was manually restricted.")
+                continue
 
-        overwrites.send_messages = False
-        audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
-        if reason:
-            audit_reason += f": {reason}"
-        await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-        await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": True}}, upsert=True)
+            overwrites.send_messages = False
+            audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
+            if reason:
+                audit_reason += f": {reason}"
+            await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": True}}, upsert=True)
 
-        msg = f"\N{LOCK} Locked {channel.mention}."
-        if reason:
-            msg += f" Reason: {reason}"
-        await ctx.send(msg, ephemeral=True)
+            msg = f"\N{LOCK} Locked {channel.mention}."
+            if reason:
+                msg += f" Reason: {reason}"
+            results.append(msg)
+
+        await ctx.send("\n".join(results), ephemeral=True)
+
+    @lock.command(name="list")
+    @commands.guild_only()
+    @checks.is_moderator()
+    async def lock_list(self, ctx):
+        """Lists all currently locked channels.
+
+        You must have the Moderator role to use this.
+        """
+
+        locked_channels = []
+        async for doc in ctx.bot.mongo.db.channel.find({"locked": True, "guild_id": ctx.guild.id}):
+            channel = ctx.guild.get_channel(doc["_id"])
+            if channel is not None:
+                locked_channels.append(f"\N{LOCK} {channel.mention}")
+
+        if not locked_channels:
+            return await ctx.send("No channels are currently locked.", ephemeral=True)
+
+        embed = discord.Embed(
+            title="Locked Channels",
+            description="\n".join(locked_channels),
+            color=discord.Color.orange(),
+        )
+        await ctx.send(embed=embed, ephemeral=True)
 
     @commands.hybrid_command()
     @commands.guild_only()
     @checks.is_moderator()
-    async def unlock(self, ctx, channel: Optional[discord.TextChannel] = None, *, reason: Optional[str] = None):
-        """Unlocks a channel by allowing members to send messages again.
+    async def unlock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, reason: Optional[str] = None):
+        """Unlocks one or more channels by allowing members to send messages again.
 
         If no channel is provided, unlocks the current channel.
 
         You must have the Moderator role to use this.
         """
 
-        channel = channel or ctx.channel
+        if not channels:
+            channels = [ctx.channel]
 
-        channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
-        is_locked_in_db = channel_data and channel_data.get("locked", False)
+        results = []
+        for channel in channels:
+            channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
+            is_locked_in_db = channel_data and channel_data.get("locked", False)
 
-        if not is_locked_in_db:
+            if not is_locked_in_db:
+                overwrites = channel.overwrites_for(ctx.guild.default_role)
+                if overwrites.send_messages is False:
+                    results.append(f"{channel.mention} cannot be unlocked because it was manually restricted.")
+                else:
+                    results.append(f"{channel.mention} is not locked.")
+                continue
+
             overwrites = channel.overwrites_for(ctx.guild.default_role)
-            if overwrites.send_messages is False:
-                return await ctx.send(
-                    f"{channel.mention} cannot be unlocked because it was manually restricted.",
-                    ephemeral=True,
-                )
-            return await ctx.send(f"{channel.mention} is not locked.", ephemeral=True)
+            overwrites.send_messages = None
+            audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
+            if reason:
+                audit_reason += f": {reason}"
+            await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": False}}, upsert=True)
 
-        overwrites = channel.overwrites_for(ctx.guild.default_role)
-        overwrites.send_messages = None
-        audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
-        if reason:
-            audit_reason += f": {reason}"
-        await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-        await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": False}}, upsert=True)
+            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
+            if reason:
+                msg += f" Reason: {reason}"
+            results.append(msg)
 
-        msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
-        if reason:
-            msg += f" Reason: {reason}"
-        await ctx.send(msg, ephemeral=True)
+        await ctx.send("\n".join(results), ephemeral=True)
 
     async def cog_unload(self):
         self.check_actions.cancel()

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -3,7 +3,7 @@ from collections import Counter
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Union
+from typing import List, Optional, Union
 import random
 
 import discord
@@ -475,13 +475,13 @@ class MemberOrIdConverter(commands.Converter):
 
 
 class LockFlags(commands.FlagConverter, case_insensitive=True):
-    channels: commands.Greedy[discord.TextChannel] = commands.flag(positional=True, default=None)
+    channels: List[discord.TextChannel] = commands.flag(positional=True, default=None)
     reason: Optional[str] = commands.flag(default=None)
     duration: Optional[time.ShortTime] = commands.flag(default=None)
 
 
 class UnlockFlags(commands.FlagConverter, case_insensitive=True):
-    channels: commands.Greedy[discord.TextChannel] = commands.flag(positional=True, default=None)
+    channels: List[discord.TextChannel] = commands.flag(positional=True, default=None)
     reason: Optional[str] = commands.flag(default=None)
 
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1160,7 +1160,7 @@ class Moderation(commands.Cog):
         action = Action.build_from_mongo(self.bot, action)
         await ctx.send(embed=action.to_info_embed())
 
-    @commands.hybrid_group(fallback="channels")
+    @commands.group(invoke_without_command=True)
     @commands.guild_only()
     @checks.is_moderator()
     async def lock(self, ctx, *, flags: LockFlags):
@@ -1254,7 +1254,7 @@ class Moderation(commands.Cog):
         except IndexError:
             await ctx.send("No channels are currently locked.")
 
-    @commands.hybrid_command()
+    @commands.command()
     @commands.guild_only()
     @checks.is_moderator()
     async def unlock(self, ctx, *, flags: UnlockFlags):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1202,22 +1202,39 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        locked_channels = []
+        bot_locked = []
+        manually_restricted = []
+
+        locked_channel_ids = set()
         async for doc in ctx.bot.mongo.db.channel.find({"locked": True, "guild_id": ctx.guild.id}):
             channel = ctx.guild.get_channel(doc["_id"])
             if channel is not None:
+                locked_channel_ids.add(channel.id)
                 line = f"\N{LOCK} {channel.mention}"
                 lock_reason = doc.get("lock_reason")
                 if lock_reason:
                     line += f" — {lock_reason}"
-                locked_channels.append(line)
+                bot_locked.append(line)
 
-        if not locked_channels:
+        for channel in ctx.guild.text_channels:
+            if channel.id in locked_channel_ids:
+                continue
+            overwrites = channel.overwrites_for(ctx.guild.default_role)
+            if overwrites.send_messages is False:
+                manually_restricted.append(f"\N{LOCK} {channel.mention} (manually restricted)")
+
+        if not bot_locked and not manually_restricted:
             return await ctx.send("No channels are currently locked.", ephemeral=True)
+
+        description_parts = []
+        if bot_locked:
+            description_parts.extend(bot_locked)
+        if manually_restricted:
+            description_parts.extend(manually_restricted)
 
         embed = discord.Embed(
             title="Locked Channels",
-            description="\n".join(locked_channels),
+            description="\n".join(description_parts),
             color=discord.Color.orange(),
         )
         await ctx.send(embed=embed, ephemeral=True)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1186,6 +1186,8 @@ class Moderation(commands.Cog):
             announce = f"\N{LOCK} This channel has been locked."
             if flags.reason:
                 announce += f" Reason: {flags.reason}"
+            if flags.duration:
+                announce += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
             await channel.send(announce)
 
             overwrites.send_messages = False

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -475,13 +475,11 @@ class MemberOrIdConverter(commands.Converter):
 
 
 class LockFlags(commands.FlagConverter, case_insensitive=True):
-    channels: List[discord.TextChannel] = commands.flag(positional=True, default=None)
     reason: Optional[str] = commands.flag(default=None)
     duration: Optional[time.ShortTime] = commands.flag(default=None)
 
 
 class UnlockFlags(commands.FlagConverter, case_insensitive=True):
-    channels: List[discord.TextChannel] = commands.flag(positional=True, default=None)
     reason: Optional[str] = commands.flag(default=None)
 
 
@@ -1163,7 +1161,7 @@ class Moderation(commands.Cog):
     @commands.group(invoke_without_command=True)
     @commands.guild_only()
     @checks.is_moderator()
-    async def lock(self, ctx, *, flags: LockFlags):
+    async def lock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, flags: LockFlags):
         """Locks one or more channels by preventing members from sending messages.
 
         If no channel is provided, locks the current channel.
@@ -1171,7 +1169,7 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        channels = flags.channels or [ctx.channel]
+        channels = channels or [ctx.channel]
 
         results = []
         for channel in channels:
@@ -1257,7 +1255,7 @@ class Moderation(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.is_moderator()
-    async def unlock(self, ctx, *, flags: UnlockFlags):
+    async def unlock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, flags: UnlockFlags):
         """Unlocks one or more channels by allowing members to send messages again.
 
         If no channel is provided, unlocks the current channel.
@@ -1265,7 +1263,7 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        channels = flags.channels or [ctx.channel]
+        channels = channels or [ctx.channel]
 
         results = []
         for channel in channels:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -13,7 +13,7 @@ from discord.ext.menus.views import ViewMenuPages
 from discord.ui import button
 
 from helpers import checks, constants, time
-from helpers.pagination import AsyncEmbedFieldsPageSource
+from helpers.pagination import AsyncEmbedFieldsPageSource, EmbedListPageSource
 from helpers.utils import FakeUser, FetchUserConverter, with_attachment_urls
 
 
@@ -1202,42 +1202,38 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        bot_locked = []
-        manually_restricted = []
-
-        locked_channel_ids = set()
+        locked_docs = {}
         async for doc in ctx.bot.mongo.db.channel.find({"locked": True, "guild_id": ctx.guild.id}):
-            channel = ctx.guild.get_channel(doc["_id"])
-            if channel is not None:
-                locked_channel_ids.add(channel.id)
+            locked_docs[doc["_id"]] = doc
+
+        entries = []
+        for channel in ctx.guild.text_channels:
+            if channel.id in locked_docs:
+                doc = locked_docs[channel.id]
                 line = f"\N{LOCK} {channel.mention}"
                 lock_reason = doc.get("lock_reason")
                 if lock_reason:
                     line += f" — {lock_reason}"
-                bot_locked.append(line)
+                entries.append(line)
+            else:
+                overwrites = channel.overwrites_for(ctx.guild.default_role)
+                if overwrites.send_messages is False:
+                    entries.append(f"\N{LOCK} {channel.mention} (manually restricted)")
 
-        for channel in ctx.guild.text_channels:
-            if channel.id in locked_channel_ids:
-                continue
-            overwrites = channel.overwrites_for(ctx.guild.default_role)
-            if overwrites.send_messages is False:
-                manually_restricted.append(f"\N{LOCK} {channel.mention} (manually restricted)")
-
-        if not bot_locked and not manually_restricted:
+        if not entries:
             return await ctx.send("No channels are currently locked.", ephemeral=True)
 
-        description_parts = []
-        if bot_locked:
-            description_parts.extend(bot_locked)
-        if manually_restricted:
-            description_parts.extend(manually_restricted)
-
-        embed = discord.Embed(
-            title="Locked Channels",
-            description="\n".join(description_parts),
-            color=discord.Color.orange(),
+        pages = ViewMenuPages(
+            source=EmbedListPageSource(
+                entries,
+                title=f"\N{LOCK} Locked Channels ({len(entries)})",
+            )
         )
-        await ctx.send(embed=embed, ephemeral=True)
+
+        try:
+            await pages.start(ctx)
+        except IndexError:
+            await ctx.send("No channels are currently locked.")
 
     @commands.hybrid_command()
     @commands.guild_only()

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1148,7 +1148,7 @@ class Moderation(commands.Cog):
         action = Action.build_from_mongo(self.bot, action)
         await ctx.send(embed=action.to_info_embed())
 
-    @commands.hybrid_group(invoke_without_command=True)
+    @commands.hybrid_group(invoke_without_command=True, fallback="channels")
     @commands.guild_only()
     @checks.is_moderator()
     async def lock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, reason: Optional[str] = None):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -474,6 +474,17 @@ class MemberOrIdConverter(commands.Converter):
             raise commands.MemberNotFound(arg)
 
 
+class LockFlags(commands.FlagConverter, case_insensitive=True):
+    channels: commands.Greedy[discord.TextChannel] = commands.flag(positional=True, default=None)
+    reason: Optional[str] = commands.flag(default=None)
+    duration: Optional[time.ShortTime] = commands.flag(default=None)
+
+
+class UnlockFlags(commands.FlagConverter, case_insensitive=True):
+    channels: commands.Greedy[discord.TextChannel] = commands.flag(positional=True, default=None)
+    reason: Optional[str] = commands.flag(default=None)
+
+
 class HistoryFlagConverter(commands.FlagConverter, case_insensitive=True):
     target: FetchUserConverter = commands.flag(max_args=1, positional=True)
     ephemeral: Optional[bool] = False
@@ -486,6 +497,7 @@ class Moderation(commands.Cog):
         self.bot = bot
         self.cls_dict = cls_dict
         self.check_actions.start()
+        self.check_expired_locks.start()
 
     @commands.Cog.listener()
     async def on_member_join(self, member):
@@ -1151,7 +1163,7 @@ class Moderation(commands.Cog):
     @commands.hybrid_group(fallback="channels")
     @commands.guild_only()
     @checks.is_moderator()
-    async def lock(self, ctx, *, channels: commands.Greedy[discord.TextChannel]):
+    async def lock(self, ctx, *, flags: LockFlags):
         """Locks one or more channels by preventing members from sending messages.
 
         If no channel is provided, locks the current channel.
@@ -1159,8 +1171,7 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        if not channels:
-            channels = [ctx.channel]
+        channels = flags.channels or [ctx.channel]
 
         results = []
         for channel in channels:
@@ -1176,12 +1187,23 @@ class Moderation(commands.Cog):
 
             overwrites.send_messages = False
             audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
+            if flags.reason:
+                audit_reason += f": {flags.reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-            await ctx.bot.mongo.db.channel.update_one(
-                {"_id": channel.id}, {"$set": {"locked": True, "guild_id": ctx.guild.id}}, upsert=True
-            )
 
-            results.append(f"\N{LOCK} Locked {channel.mention}.")
+            update_fields = {"locked": True, "guild_id": ctx.guild.id}
+            if flags.reason:
+                update_fields["lock_reason"] = flags.reason
+            if flags.duration:
+                update_fields["lock_expires_at"] = flags.duration.dt
+            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
+
+            msg = f"\N{LOCK} Locked {channel.mention}."
+            if flags.reason:
+                msg += f" Reason: {flags.reason}"
+            if flags.duration:
+                msg += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
+            results.append(msg)
 
         await ctx.send("\n".join(results), ephemeral=True)
 
@@ -1194,14 +1216,24 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        locked_ids = set()
+        locked_docs = {}
         async for doc in ctx.bot.mongo.db.channel.find({"locked": True, "guild_id": ctx.guild.id}):
-            locked_ids.add(doc["_id"])
+            locked_docs[doc["_id"]] = doc
 
         entries = []
         for channel in ctx.guild.text_channels:
-            if channel.id in locked_ids:
-                entries.append(f"\N{LOCK} {channel.mention}")
+            if channel.id in locked_docs:
+                doc = locked_docs[channel.id]
+                line = f"\N{LOCK} {channel.mention}"
+                lock_reason = doc.get("lock_reason")
+                if lock_reason:
+                    line += f" \u2014 {lock_reason}"
+                expires_at = doc.get("lock_expires_at")
+                if expires_at:
+                    if expires_at.tzinfo is None:
+                        expires_at = expires_at.replace(tzinfo=timezone.utc)
+                    line += f" (expires {discord.utils.format_dt(expires_at, 'R')})"
+                entries.append(line)
             else:
                 overwrites = channel.overwrites_for(ctx.guild.default_role)
                 if overwrites.send_messages is False:
@@ -1222,10 +1254,10 @@ class Moderation(commands.Cog):
         except IndexError:
             await ctx.send("No channels are currently locked.")
 
-    @commands.hybrid_group(fallback="channels")
+    @commands.hybrid_command()
     @commands.guild_only()
     @checks.is_moderator()
-    async def unlock(self, ctx, *, channels: commands.Greedy[discord.TextChannel]):
+    async def unlock(self, ctx, *, flags: UnlockFlags):
         """Unlocks one or more channels by allowing members to send messages again.
 
         If no channel is provided, unlocks the current channel.
@@ -1233,8 +1265,7 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        if not channels:
-            channels = [ctx.channel]
+        channels = flags.channels or [ctx.channel]
 
         results = []
         for channel in channels:
@@ -1252,19 +1283,47 @@ class Moderation(commands.Cog):
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = None
             audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
+            if flags.reason:
+                audit_reason += f": {flags.reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             await ctx.bot.mongo.db.channel.update_one(
                 {"_id": channel.id},
-                {"$set": {"locked": False, "guild_id": ctx.guild.id}},
+                {
+                    "$set": {"locked": False, "guild_id": ctx.guild.id},
+                    "$unset": {"lock_reason": 1, "lock_expires_at": 1},
+                },
                 upsert=True,
             )
 
-            results.append(f"\N{OPEN LOCK} Unlocked {channel.mention}.")
+            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
+            if flags.reason:
+                msg += f" Reason: {flags.reason}"
+            results.append(msg)
 
         await ctx.send("\n".join(results), ephemeral=True)
 
+    @tasks.loop(seconds=30)
+    async def check_expired_locks(self):
+        await self.bot.wait_until_ready()
+        query = {"locked": True, "lock_expires_at": {"$lt": datetime.now(timezone.utc)}}
+        async for doc in self.bot.mongo.db.channel.find(query):
+            guild = self.bot.get_guild(doc.get("guild_id"))
+            if guild is not None:
+                channel = guild.get_channel(doc["_id"])
+                if channel is not None:
+                    overwrites = channel.overwrites_for(guild.default_role)
+                    overwrites.send_messages = None
+                    await channel.set_permissions(
+                        guild.default_role, overwrite=overwrites, reason="Lock duration expired"
+                    )
+            await self.bot.mongo.db.channel.update_one(
+                {"_id": doc["_id"]},
+                {"$set": {"locked": False}, "$unset": {"lock_reason": 1, "lock_expires_at": 1}},
+            )
+
     async def cog_unload(self):
         self.check_actions.cancel()
+        self.check_expired_locks.cancel()
 
 
 async def setup(bot):

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1179,9 +1179,12 @@ class Moderation(commands.Cog):
             if reason:
                 audit_reason += f": {reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-            await ctx.bot.mongo.db.channel.update_one(
-                {"_id": channel.id}, {"$set": {"locked": True, "guild_id": ctx.guild.id}}, upsert=True
-            )
+            update_fields = {"locked": True, "guild_id": ctx.guild.id}
+            if reason:
+                update_fields["lock_reason"] = reason
+            else:
+                update_fields["lock_reason"] = None
+            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
 
             msg = f"\N{LOCK} Locked {channel.mention}."
             if reason:
@@ -1203,7 +1206,11 @@ class Moderation(commands.Cog):
         async for doc in ctx.bot.mongo.db.channel.find({"locked": True, "guild_id": ctx.guild.id}):
             channel = ctx.guild.get_channel(doc["_id"])
             if channel is not None:
-                locked_channels.append(f"\N{LOCK} {channel.mention}")
+                line = f"\N{LOCK} {channel.mention}"
+                lock_reason = doc.get("lock_reason")
+                if lock_reason:
+                    line += f" — {lock_reason}"
+                locked_channels.append(line)
 
         if not locked_channels:
             return await ctx.send("No channels are currently locked.", ephemeral=True)
@@ -1249,7 +1256,9 @@ class Moderation(commands.Cog):
                 audit_reason += f": {reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             await ctx.bot.mongo.db.channel.update_one(
-                {"_id": channel.id}, {"$set": {"locked": False, "guild_id": ctx.guild.id}}, upsert=True
+                {"_id": channel.id},
+                {"$set": {"locked": False, "guild_id": ctx.guild.id, "lock_reason": None}},
+                upsert=True,
             )
 
             msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1163,6 +1163,13 @@ class Moderation(commands.Cog):
         overwrites = channel.overwrites_for(ctx.guild.default_role)
 
         if overwrites.send_messages is False:
+            return await ctx.send(
+                f"{channel.mention} cannot be locked because @everyone already doesn't have access to chat there.",
+                ephemeral=True,
+            )
+
+        channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
+        if channel_data and channel_data.get("locked", False):
             return await ctx.send(f"{channel.mention} is already locked.", ephemeral=True)
 
         overwrites.send_messages = False
@@ -1170,6 +1177,7 @@ class Moderation(commands.Cog):
         if reason:
             audit_reason += f": {reason}"
         await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+        await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": True}}, upsert=True)
 
         msg = f"\N{LOCK} Locked {channel.mention}."
         if reason:
@@ -1188,16 +1196,18 @@ class Moderation(commands.Cog):
         """
 
         channel = channel or ctx.channel
-        overwrites = channel.overwrites_for(ctx.guild.default_role)
 
-        if overwrites.send_messages is not False:
+        channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
+        if not channel_data or not channel_data.get("locked", False):
             return await ctx.send(f"{channel.mention} is not locked.", ephemeral=True)
 
+        overwrites = channel.overwrites_for(ctx.guild.default_role)
         overwrites.send_messages = None
         audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
         if reason:
             audit_reason += f": {reason}"
         await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+        await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": False}}, upsert=True)
 
         msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
         if reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1148,10 +1148,10 @@ class Moderation(commands.Cog):
         action = Action.build_from_mongo(self.bot, action)
         await ctx.send(embed=action.to_info_embed())
 
-    @commands.hybrid_group(invoke_without_command=True, fallback="channels")
+    @commands.hybrid_group(fallback="channels")
     @commands.guild_only()
     @checks.is_moderator()
-    async def lock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, reason: Optional[str] = None):
+    async def lock(self, ctx, *, channels: commands.Greedy[discord.TextChannel]):
         """Locks one or more channels by preventing members from sending messages.
 
         If no channel is provided, locks the current channel.
@@ -1176,20 +1176,12 @@ class Moderation(commands.Cog):
 
             overwrites.send_messages = False
             audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
-            if reason:
-                audit_reason += f": {reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-            update_fields = {"locked": True, "guild_id": ctx.guild.id}
-            if reason:
-                update_fields["lock_reason"] = reason
-            else:
-                update_fields["lock_reason"] = None
-            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
+            await ctx.bot.mongo.db.channel.update_one(
+                {"_id": channel.id}, {"$set": {"locked": True, "guild_id": ctx.guild.id}}, upsert=True
+            )
 
-            msg = f"\N{LOCK} Locked {channel.mention}."
-            if reason:
-                msg += f" Reason: {reason}"
-            results.append(msg)
+            results.append(f"\N{LOCK} Locked {channel.mention}.")
 
         await ctx.send("\n".join(results), ephemeral=True)
 
@@ -1202,19 +1194,14 @@ class Moderation(commands.Cog):
         You must have the Moderator role to use this.
         """
 
-        locked_docs = {}
+        locked_ids = set()
         async for doc in ctx.bot.mongo.db.channel.find({"locked": True, "guild_id": ctx.guild.id}):
-            locked_docs[doc["_id"]] = doc
+            locked_ids.add(doc["_id"])
 
         entries = []
         for channel in ctx.guild.text_channels:
-            if channel.id in locked_docs:
-                doc = locked_docs[channel.id]
-                line = f"\N{LOCK} {channel.mention}"
-                lock_reason = doc.get("lock_reason")
-                if lock_reason:
-                    line += f" — {lock_reason}"
-                entries.append(line)
+            if channel.id in locked_ids:
+                entries.append(f"\N{LOCK} {channel.mention}")
             else:
                 overwrites = channel.overwrites_for(ctx.guild.default_role)
                 if overwrites.send_messages is False:
@@ -1235,10 +1222,10 @@ class Moderation(commands.Cog):
         except IndexError:
             await ctx.send("No channels are currently locked.")
 
-    @commands.hybrid_group(invoke_without_command=True, fallback="channels")
+    @commands.hybrid_group(fallback="channels")
     @commands.guild_only()
     @checks.is_moderator()
-    async def unlock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, reason: Optional[str] = None):
+    async def unlock(self, ctx, *, channels: commands.Greedy[discord.TextChannel]):
         """Unlocks one or more channels by allowing members to send messages again.
 
         If no channel is provided, unlocks the current channel.
@@ -1265,19 +1252,14 @@ class Moderation(commands.Cog):
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = None
             audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
-            if reason:
-                audit_reason += f": {reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             await ctx.bot.mongo.db.channel.update_one(
                 {"_id": channel.id},
-                {"$set": {"locked": False, "guild_id": ctx.guild.id, "lock_reason": None}},
+                {"$set": {"locked": False, "guild_id": ctx.guild.id}},
                 upsert=True,
             )
 
-            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
-            if reason:
-                msg += f" Reason: {reason}"
-            results.append(msg)
+            results.append(f"\N{OPEN LOCK} Unlocked {channel.mention}.")
 
         await ctx.send("\n".join(results), ephemeral=True)
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1205,7 +1205,11 @@ class Moderation(commands.Cog):
             audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
             if flags.reason:
                 audit_reason += f": {flags.reason}"
-            await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+            try:
+                await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+            except discord.Forbidden:
+                results.append(f"Failed to lock {channel.mention}: missing permissions.")
+                continue
 
             update_fields = {"locked": True, "guild_id": ctx.guild.id}
             if flags.reason:
@@ -1302,7 +1306,11 @@ class Moderation(commands.Cog):
             audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
             if flags.reason:
                 audit_reason += f": {flags.reason}"
-            await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+            try:
+                await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
+            except discord.Forbidden:
+                results.append(f"Failed to unlock {channel.mention}: missing permissions.")
+                continue
             await ctx.bot.mongo.db.channel.update_one(
                 {"_id": channel.id},
                 {

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1302,24 +1302,25 @@ class Moderation(commands.Cog):
 
         await ctx.send("\n".join(results), ephemeral=True)
 
+    async def reverse_expired_lock(self, doc):
+        guild = self.bot.get_guild(doc.get("guild_id"))
+        if guild is not None:
+            channel = guild.get_channel(doc["_id"])
+            if channel is not None:
+                overwrites = channel.overwrites_for(guild.default_role)
+                overwrites.send_messages = None
+                await channel.set_permissions(guild.default_role, overwrite=overwrites, reason="Lock duration expired")
+        await self.bot.mongo.db.channel.update_one(
+            {"_id": doc["_id"]},
+            {"$set": {"locked": False}, "$unset": {"lock_reason": 1, "lock_expires_at": 1}},
+        )
+
     @tasks.loop(seconds=30)
     async def check_expired_locks(self):
         await self.bot.wait_until_ready()
         query = {"locked": True, "lock_expires_at": {"$lt": datetime.now(timezone.utc)}}
         async for doc in self.bot.mongo.db.channel.find(query):
-            guild = self.bot.get_guild(doc.get("guild_id"))
-            if guild is not None:
-                channel = guild.get_channel(doc["_id"])
-                if channel is not None:
-                    overwrites = channel.overwrites_for(guild.default_role)
-                    overwrites.send_messages = None
-                    await channel.set_permissions(
-                        guild.default_role, overwrite=overwrites, reason="Lock duration expired"
-                    )
-            await self.bot.mongo.db.channel.update_one(
-                {"_id": doc["_id"]},
-                {"$set": {"locked": False}, "$unset": {"lock_reason": 1, "lock_expires_at": 1}},
-            )
+            self.bot.loop.create_task(self.reverse_expired_lock(doc))
 
     async def cog_unload(self):
         self.check_actions.cancel()

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1196,6 +1196,11 @@ class Moderation(commands.Cog):
                 update_fields["lock_expires_at"] = flags.duration.dt
             await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
 
+            announce = f"\N{LOCK} This channel has been locked."
+            if flags.reason:
+                announce += f" Reason: {flags.reason}"
+            await channel.send(announce)
+
             msg = f"\N{LOCK} Locked {channel.mention}."
             if flags.reason:
                 msg += f" Reason: {flags.reason}"
@@ -1292,6 +1297,11 @@ class Moderation(commands.Cog):
                 },
                 upsert=True,
             )
+
+            announce = f"\N{OPEN LOCK} This channel has been unlocked."
+            if flags.reason:
+                announce += f" Reason: {flags.reason}"
+            await channel.send(announce)
 
             msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
             if flags.reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1189,7 +1189,11 @@ class Moderation(commands.Cog):
                 announce += f" Reason: {flags.reason}"
             if flags.duration:
                 announce += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
-            await channel.send(announce)
+            try:
+                await channel.send(announce)
+            except discord.Forbidden:
+                results.append(f"Failed to lock {channel.mention}: missing access.")
+                continue
 
             msg = f"\N{LOCK} Locked {channel.mention}."
             if flags.reason:
@@ -1323,7 +1327,10 @@ class Moderation(commands.Cog):
             announce = f"\N{OPEN LOCK} This channel has been unlocked."
             if flags.reason:
                 announce += f" Reason: {flags.reason}"
-            await channel.send(announce)
+            try:
+                await channel.send(announce)
+            except discord.Forbidden:
+                pass
 
         await ctx.send("\n".join(results), ephemeral=True)
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1183,6 +1183,11 @@ class Moderation(commands.Cog):
                 results.append(f"{channel.mention} cannot be locked because it was manually restricted.")
                 continue
 
+            announce = f"\N{LOCK} This channel has been locked."
+            if flags.reason:
+                announce += f" Reason: {flags.reason}"
+            await channel.send(announce)
+
             overwrites.send_messages = False
             audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
             if flags.reason:
@@ -1195,11 +1200,6 @@ class Moderation(commands.Cog):
             if flags.duration:
                 update_fields["lock_expires_at"] = flags.duration.dt
             await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
-
-            announce = f"\N{LOCK} This channel has been locked."
-            if flags.reason:
-                announce += f" Reason: {flags.reason}"
-            await channel.send(announce)
 
             msg = f"\N{LOCK} Locked {channel.mention}."
             if flags.reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1336,6 +1336,12 @@ class Moderation(commands.Cog):
         if guild is not None:
             channel = guild.get_channel(doc["_id"])
             if channel is not None:
+                try:
+                    await channel.send(
+                        "\N{OPEN LOCK} This channel has been automatically unlocked (lock duration expired)."
+                    )
+                except discord.Forbidden:
+                    pass
                 overwrites = channel.overwrites_for(guild.default_role)
                 overwrites.send_messages = None
                 await channel.set_permissions(guild.default_role, overwrite=overwrites, reason="Lock duration expired")

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1192,8 +1192,7 @@ class Moderation(commands.Cog):
             try:
                 await channel.send(announce)
             except discord.Forbidden:
-                results.append(f"Failed to lock {channel.mention}: missing access.")
-                continue
+                pass
 
             msg = f"\N{LOCK} Locked {channel.mention}."
             if flags.reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1179,7 +1179,9 @@ class Moderation(commands.Cog):
             if reason:
                 audit_reason += f": {reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": True}}, upsert=True)
+            await ctx.bot.mongo.db.channel.update_one(
+                {"_id": channel.id}, {"$set": {"locked": True, "guild_id": ctx.guild.id}}, upsert=True
+            )
 
             msg = f"\N{LOCK} Locked {channel.mention}."
             if reason:
@@ -1246,7 +1248,9 @@ class Moderation(commands.Cog):
             if reason:
                 audit_reason += f": {reason}"
             await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
-            await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": {"locked": False}}, upsert=True)
+            await ctx.bot.mongo.db.channel.update_one(
+                {"_id": channel.id}, {"$set": {"locked": False, "guild_id": ctx.guild.id}}, upsert=True
+            )
 
             msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
             if reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1336,15 +1336,15 @@ class Moderation(commands.Cog):
         if guild is not None:
             channel = guild.get_channel(doc["_id"])
             if channel is not None:
+                overwrites = channel.overwrites_for(guild.default_role)
+                overwrites.send_messages = None
+                await channel.set_permissions(guild.default_role, overwrite=overwrites, reason="Lock duration expired")
                 try:
                     await channel.send(
                         "\N{OPEN LOCK} This channel has been automatically unlocked (lock duration expired)."
                     )
                 except discord.Forbidden:
                     pass
-                overwrites = channel.overwrites_for(guild.default_role)
-                overwrites.send_messages = None
-                await channel.set_permissions(guild.default_role, overwrite=overwrites, reason="Lock duration expired")
         await self.bot.mongo.db.channel.update_one(
             {"_id": doc["_id"]},
             {"$set": {"locked": False}, "$unset": {"lock_reason": 1, "lock_expires_at": 1}},

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1168,7 +1168,7 @@ class Moderation(commands.Cog):
         overwrites = channel.overwrites_for(ctx.guild.default_role)
         if overwrites.send_messages is False:
             return await ctx.send(
-                f"{channel.mention} cannot be locked because @everyone already doesn't have access to chat there.",
+                f"{channel.mention} cannot be locked because it was manually restricted.",
                 ephemeral=True,
             )
 
@@ -1199,12 +1199,17 @@ class Moderation(commands.Cog):
 
         channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
         is_locked_in_db = channel_data and channel_data.get("locked", False)
-        overwrites = channel.overwrites_for(ctx.guild.default_role)
-        is_locked_in_perms = overwrites.send_messages is False
 
-        if not is_locked_in_db and not is_locked_in_perms:
+        if not is_locked_in_db:
+            overwrites = channel.overwrites_for(ctx.guild.default_role)
+            if overwrites.send_messages is False:
+                return await ctx.send(
+                    f"{channel.mention} cannot be unlocked because it was manually restricted.",
+                    ephemeral=True,
+                )
             return await ctx.send(f"{channel.mention} is not locked.", ephemeral=True)
 
+        overwrites = channel.overwrites_for(ctx.guild.default_role)
         overwrites.send_messages = None
         audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
         if reason:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1302,8 +1302,6 @@ class Moderation(commands.Cog):
             results.append(msg)
             to_unlock.append(channel)
 
-        await ctx.send("\n".join(results), ephemeral=True)
-
         for channel in to_unlock:
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = None
@@ -1330,6 +1328,8 @@ class Moderation(commands.Cog):
                 await channel.send(announce)
             except discord.Forbidden:
                 pass
+
+        await ctx.send("\n".join(results), ephemeral=True)
 
     async def reverse_expired_lock(self, doc):
         guild = self.bot.get_guild(doc.get("guild_id"))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1172,6 +1172,7 @@ class Moderation(commands.Cog):
         channels = channels or [ctx.channel]
 
         results = []
+        to_lock = []
         for channel in channels:
             channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
             if channel_data and channel_data.get("locked", False):
@@ -1190,6 +1191,16 @@ class Moderation(commands.Cog):
                 announce += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
             await channel.send(announce)
 
+            msg = f"\N{LOCK} Locked {channel.mention}."
+            if flags.reason:
+                msg += f" Reason: {flags.reason}"
+            if flags.duration:
+                msg += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
+            results.append(msg)
+            to_lock.append(channel)
+
+        for channel in to_lock:
+            overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = False
             audit_reason = f"Locked by {ctx.author} (ID: {ctx.author.id})"
             if flags.reason:
@@ -1202,13 +1213,6 @@ class Moderation(commands.Cog):
             if flags.duration:
                 update_fields["lock_expires_at"] = flags.duration.dt
             await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
-
-            msg = f"\N{LOCK} Locked {channel.mention}."
-            if flags.reason:
-                msg += f" Reason: {flags.reason}"
-            if flags.duration:
-                msg += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
-            results.append(msg)
 
         await ctx.send("\n".join(results), ephemeral=True)
 
@@ -1273,6 +1277,7 @@ class Moderation(commands.Cog):
         channels = channels or [ctx.channel]
 
         results = []
+        to_unlock = []
         for channel in channels:
             channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
             is_locked_in_db = channel_data and channel_data.get("locked", False)
@@ -1285,6 +1290,13 @@ class Moderation(commands.Cog):
                     results.append(f"{channel.mention} is not locked.")
                 continue
 
+            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
+            if flags.reason:
+                msg += f" Reason: {flags.reason}"
+            results.append(msg)
+            to_unlock.append(channel)
+
+        for channel in to_unlock:
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = None
             audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
@@ -1304,11 +1316,6 @@ class Moderation(commands.Cog):
             if flags.reason:
                 announce += f" Reason: {flags.reason}"
             await channel.send(announce)
-
-            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
-            if flags.reason:
-                msg += f" Reason: {flags.reason}"
-            results.append(msg)
 
         await ctx.send("\n".join(results), ephemeral=True)
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1202,6 +1202,8 @@ class Moderation(commands.Cog):
             results.append(msg)
             to_lock.append(channel)
 
+        await ctx.send("\n".join(results), ephemeral=True)
+
         for channel in to_lock:
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = False
@@ -1211,7 +1213,6 @@ class Moderation(commands.Cog):
             try:
                 await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             except discord.Forbidden:
-                results.append(f"Failed to lock {channel.mention}: missing permissions.")
                 continue
 
             update_fields = {"locked": True, "guild_id": ctx.guild.id}
@@ -1220,8 +1221,6 @@ class Moderation(commands.Cog):
             if flags.duration:
                 update_fields["lock_expires_at"] = flags.duration.dt
             await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
-
-        await ctx.send("\n".join(results), ephemeral=True)
 
     @lock.command(name="list")
     @commands.guild_only()
@@ -1303,6 +1302,8 @@ class Moderation(commands.Cog):
             results.append(msg)
             to_unlock.append(channel)
 
+        await ctx.send("\n".join(results), ephemeral=True)
+
         for channel in to_unlock:
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = None
@@ -1312,7 +1313,6 @@ class Moderation(commands.Cog):
             try:
                 await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             except discord.Forbidden:
-                results.append(f"Failed to unlock {channel.mention}: missing permissions.")
                 continue
             await ctx.bot.mongo.db.channel.update_one(
                 {"_id": channel.id},
@@ -1330,8 +1330,6 @@ class Moderation(commands.Cog):
                 await channel.send(announce)
             except discord.Forbidden:
                 pass
-
-        await ctx.send("\n".join(results), ephemeral=True)
 
     async def reverse_expired_lock(self, doc):
         guild = self.bot.get_guild(doc.get("guild_id"))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1235,7 +1235,7 @@ class Moderation(commands.Cog):
         except IndexError:
             await ctx.send("No channels are currently locked.")
 
-    @commands.hybrid_command()
+    @commands.hybrid_group(invoke_without_command=True, fallback="channels")
     @commands.guild_only()
     @checks.is_moderator()
     async def unlock(self, ctx, channels: commands.Greedy[discord.TextChannel], *, reason: Optional[str] = None):


### PR DESCRIPTION
## Summary

Changes the `lock`/`unlock` commands to track locked channel state via a `locked` boolean field in the MongoDB `channel` collection, rather than relying solely on `@everyone`'s `send_messages` permission overwrite to determine lock status. Both commands now reject manually restricted channels (where `@everyone` already has `send_messages=False` without a corresponding DB record).

**Lock command** (now a `hybrid_group` with `invoke_without_command=True`):
- Accepts multiple channels: `?lock #ch1 #ch2 ...` (defaults to current channel if none provided)
- First checks MongoDB for `locked: True` to detect already-locked channels
- Then checks if `@everyone` already has `send_messages=False` — if so, rejects the lock with "cannot be locked because it was manually restricted"
- On success, sets the permission overwrite AND writes `locked: True` to the channel document

**Unlock command:**
- Accepts multiple channels: `?unlock #ch1 #ch2 ...` (defaults to current channel if none provided)
- Only unlocks channels with `locked: True` in MongoDB (no perm fallback)
- If the channel has `send_messages=False` but no DB `locked` record, tells the user "cannot be unlocked because it was manually restricted"
- If the channel has no restriction at all and no DB record, says "not locked"
- On success, resets the permission overwrite AND writes `locked: False` to the channel document

**New `?lock list` subcommand:**
- Lists all channels in the current guild with `locked: True` in MongoDB
- Displays results in an embed with channel mentions

When multiple channels are provided, results for each channel are collected and sent in a single response.

## Review & Testing Checklist for Human

- [x] **Hybrid group slash command compatibility**: `lock` changed from `hybrid_command` to `hybrid_group`. Verify that `/lock` still works as expected in Discord's slash command UI and that `Greedy[TextChannel]` resolves correctly for both prefix and slash invocations.
- [x] **Pre-existing locked channels**: Channels locked before this change is deployed have no `locked: True` record in MongoDB. The `unlock` command will refuse to unlock them ("manually restricted"). You'll need to either manually insert `locked: True` in the DB for currently-locked channels, or unlock them by editing Discord permissions directly. Consider whether a one-time migration is needed.
- [x] **State desync if perms are changed outside the bot**: If someone manually edits channel permissions in Discord (e.g., re-enables `send_messages` for @everyone without using `unlock`), the DB will still say `locked: True`. The `lock` command won't re-lock it (DB says locked), and `unlock` will reset `send_messages` to `None` even though it wasn't `False`. Confirm this behavior is acceptable.
- [ ] **Test end-to-end**:
  - Lock a single channel → verify it locks and DB has `locked: True`
  - Lock multiple channels at once → verify all lock correctly
  - Unlock single and multiple channels → verify perms reset and DB has `locked: False`
  - Try locking a channel where @everyone already can't send messages → verify "manually restricted"
  - Try re-locking an already-locked channel → verify "already locked"
  - Try unlocking a channel that was never locked → verify "not locked"
  - Try unlocking a manually restricted channel → verify "manually restricted"
  - Run `?lock list` → verify it shows only bot-locked channels

### Notes
- The `locked` field is written with `upsert=True`, so it will create a channel document if one doesn't already exist (the logging cog normally creates these via `make_cache_channel`).
- Permissions are still modified alongside the DB update — this change adds tracking, it doesn't remove the actual permission enforcement.

Link to Devin session: https://app.devin.ai/sessions/8a37bf86ed7841c580d5ca16168d42e6
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/69" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
