### PR TITLE
feat: react with 📌 on pin and unreact on unpin

### DIFF
--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -310,6 +310,9 @@ class Pins(commands.Cog):
         if "pinned" not in payload.data:
             return
 
+        if payload.guild_id is None:
+            return
+
         channel = self.bot.get_channel(payload.channel_id)
         if channel is None:
             try:

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -305,6 +305,34 @@ class Pins(commands.Cog):
 
         await ctx.send(embed=embed)
 
+    @commands.Cog.listener()
+    async def on_raw_message_edit(self, payload):
+        if "pinned" not in payload.data:
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(payload.channel_id)
+            except (discord.NotFound, discord.Forbidden):
+                return
+
+        try:
+            message = await channel.fetch_message(payload.message_id)
+        except (discord.NotFound, discord.Forbidden):
+            return
+
+        if payload.data["pinned"]:
+            try:
+                await message.add_reaction("\N{PUSHPIN}")
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+        else:
+            try:
+                await message.remove_reaction("\N{PUSHPIN}", self.bot.user)
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+
     # Timed pin dispatch system (modeled after reminders)
 
     async def get_next_timed_pin(self):

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -306,33 +306,21 @@ class Pins(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.Cog.listener()
-    async def on_raw_message_edit(self, payload):
-        if "pinned" not in payload.data:
+    async def on_message_edit(self, before, after):
+        if before.guild is None:
             return
 
-        if payload.guild_id is None:
+        if before.pinned == after.pinned:
             return
 
-        channel = self.bot.get_channel(payload.channel_id)
-        if channel is None:
+        if after.pinned:
             try:
-                channel = await self.bot.fetch_channel(payload.channel_id)
-            except (discord.NotFound, discord.Forbidden):
-                return
-
-        try:
-            message = await channel.fetch_message(payload.message_id)
-        except (discord.NotFound, discord.Forbidden):
-            return
-
-        if payload.data["pinned"]:
-            try:
-                await message.add_reaction("\N{PUSHPIN}")
+                await after.add_reaction("\N{PUSHPIN}")
             except (discord.Forbidden, discord.HTTPException):
                 pass
         else:
             try:
-                await message.remove_reaction("\N{PUSHPIN}", self.bot.user)
+                await after.remove_reaction("\N{PUSHPIN}", self.bot.user)
             except (discord.Forbidden, discord.HTTPException):
                 pass
 

--- a/cogs/pins.py
+++ b/cogs/pins.py
@@ -183,6 +183,11 @@ class Pins(commands.Cog):
             # Unpin the message (toggle off)
             await target.unpin(reason=f"Unpinned by {ctx.author} (ID: {ctx.author.id})")
 
+            try:
+                await target.remove_reaction("\N{PUSHPIN}", self.bot.user)
+            except (discord.Forbidden, discord.HTTPException):
+                pass
+
             # Resolve any timed pin for this message
             await self.bot.mongo.db.timed_pin.update_many(
                 {"message_id": target.id, "channel_id": ctx.channel.id, "resolved": False},
@@ -197,6 +202,11 @@ class Pins(commands.Cog):
 
         # Pin the message (toggle on)
         await target.pin(reason=f"Pinned by {ctx.author} (ID: {ctx.author.id})")
+
+        try:
+            await target.add_reaction("\N{PUSHPIN}")
+        except (discord.Forbidden, discord.HTTPException):
+            pass
 
         if duration is not None:
             timed_pin = TimedPin(
@@ -305,25 +315,6 @@ class Pins(commands.Cog):
 
         await ctx.send(embed=embed)
 
-    @commands.Cog.listener()
-    async def on_message_edit(self, before, after):
-        if before.guild is None:
-            return
-
-        if before.pinned == after.pinned:
-            return
-
-        if after.pinned:
-            try:
-                await after.add_reaction("\N{PUSHPIN}")
-            except (discord.Forbidden, discord.HTTPException):
-                pass
-        else:
-            try:
-                await after.remove_reaction("\N{PUSHPIN}", self.bot.user)
-            except (discord.Forbidden, discord.HTTPException):
-                pass
-
     # Timed pin dispatch system (modeled after reminders)
 
     async def get_next_timed_pin(self):
@@ -376,6 +367,10 @@ class Pins(commands.Cog):
             message = await channel.fetch_message(timed_pin.message_id)
             if message.pinned:
                 await message.unpin(reason="Timed pin expired")
+                try:
+                    await message.remove_reaction("\N{PUSHPIN}", self.bot.user)
+                except (discord.Forbidden, discord.HTTPException):
+                    pass
                 await channel.send(
                     f"\N{PUSHPIN} A temporarily pinned message has been automatically unpinned.",
                     reference=message,


### PR DESCRIPTION
## Summary

Adds 📌 reactions directly in the `?pin` command handlers rather than via an event listener:

- **Pin**: After pinning a message via `?pin`, the bot adds a 📌 reaction to the target message.
- **Unpin**: After unpinning a message via `?pin` (toggle off), the bot removes its 📌 reaction.
- **Timed pin expiry**: When a timed pin expires and is automatically unpinned, the bot also removes its 📌 reaction.

All reaction calls are wrapped in `try/except (discord.Forbidden, discord.HTTPException)` for resilience.

## Review & Testing Checklist for Human

- [ ] **Only covers bot-initiated pins**: This does not react/unreact for pins made through Discord's native UI — only through `?pin` and timed pin expiry. Verify this is the intended behavior.
- [ ] **Test end-to-end**: Pin a message via `?pin` → verify bot reacts with 📌. Run `?pin` again on the same message to unpin → verify bot removes its 📌 reaction. Test a timed pin (e.g. `?pin <msg> 1m`) and confirm the reaction is removed on expiry.

### Notes
- Errors from the reaction API calls are silently swallowed, which is fine for resilience but makes debugging harder if the bot lacks reaction permissions in a channel.

Link to Devin session: https://app.devin.ai/sessions/8cda8011abd148bb8070e5bfd65a34c8
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
