### PR TITLE
fix: address review findings on lock/unlock commands

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1194,15 +1194,7 @@ class Moderation(commands.Cog):
             except discord.Forbidden:
                 pass
 
-            msg = f"\N{LOCK} Locked {channel.mention}."
-            if flags.reason:
-                msg += f" Reason: {flags.reason}"
-            if flags.duration:
-                msg += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
-            results.append(msg)
             to_lock.append(channel)
-
-        await ctx.send("\n".join(results), ephemeral=True)
 
         for channel in to_lock:
             overwrites = channel.overwrites_for(ctx.guild.default_role)
@@ -1213,6 +1205,7 @@ class Moderation(commands.Cog):
             try:
                 await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             except discord.Forbidden:
+                results.append(f"Failed to lock {channel.mention}: missing permissions.")
                 continue
 
             update_fields = {"locked": True, "guild_id": ctx.guild.id}
@@ -1221,6 +1214,15 @@ class Moderation(commands.Cog):
             if flags.duration:
                 update_fields["lock_expires_at"] = flags.duration.dt
             await ctx.bot.mongo.db.channel.update_one({"_id": channel.id}, {"$set": update_fields}, upsert=True)
+
+            msg = f"\N{LOCK} Locked {channel.mention}."
+            if flags.reason:
+                msg += f" Reason: {flags.reason}"
+            if flags.duration:
+                msg += f" Expires {discord.utils.format_dt(flags.duration.dt, 'R')}."
+            results.append(msg)
+
+        await ctx.send("\n".join(results), ephemeral=True)
 
     @lock.command(name="list")
     @commands.guild_only()
@@ -1283,7 +1285,6 @@ class Moderation(commands.Cog):
         channels = channels or [ctx.channel]
 
         results = []
-        to_unlock = []
         for channel in channels:
             channel_data = await ctx.bot.mongo.db.channel.find_one({"_id": channel.id})
             is_locked_in_db = channel_data and channel_data.get("locked", False)
@@ -1296,13 +1297,6 @@ class Moderation(commands.Cog):
                     results.append(f"{channel.mention} is not locked.")
                 continue
 
-            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
-            if flags.reason:
-                msg += f" Reason: {flags.reason}"
-            results.append(msg)
-            to_unlock.append(channel)
-
-        for channel in to_unlock:
             overwrites = channel.overwrites_for(ctx.guild.default_role)
             overwrites.send_messages = None
             audit_reason = f"Unlocked by {ctx.author} (ID: {ctx.author.id})"
@@ -1311,7 +1305,9 @@ class Moderation(commands.Cog):
             try:
                 await channel.set_permissions(ctx.guild.default_role, overwrite=overwrites, reason=audit_reason)
             except discord.Forbidden:
+                results.append(f"Failed to unlock {channel.mention}: missing permissions.")
                 continue
+
             await ctx.bot.mongo.db.channel.update_one(
                 {"_id": channel.id},
                 {
@@ -1329,6 +1325,11 @@ class Moderation(commands.Cog):
             except discord.Forbidden:
                 pass
 
+            msg = f"\N{OPEN LOCK} Unlocked {channel.mention}."
+            if flags.reason:
+                msg += f" Reason: {flags.reason}"
+            results.append(msg)
+
         await ctx.send("\n".join(results), ephemeral=True)
 
     async def reverse_expired_lock(self, doc):
@@ -1338,7 +1339,12 @@ class Moderation(commands.Cog):
             if channel is not None:
                 overwrites = channel.overwrites_for(guild.default_role)
                 overwrites.send_messages = None
-                await channel.set_permissions(guild.default_role, overwrite=overwrites, reason="Lock duration expired")
+                try:
+                    await channel.set_permissions(
+                        guild.default_role, overwrite=overwrites, reason="Lock duration expired"
+                    )
+                except discord.Forbidden:
+                    pass
                 try:
                     await channel.send(
                         "\N{OPEN LOCK} This channel has been automatically unlocked (lock duration expired)."
@@ -1346,7 +1352,7 @@ class Moderation(commands.Cog):
                 except discord.Forbidden:
                     pass
         await self.bot.mongo.db.channel.update_one(
-            {"_id": doc["_id"]},
+            {"_id": doc["_id"], "lock_expires_at": doc.get("lock_expires_at")},
             {"$set": {"locked": False}, "$unset": {"lock_reason": 1, "lock_expires_at": 1}},
         )
 


### PR DESCRIPTION
## Summary

Fixes four bugs from the [Devin Review on PR #69](https://github.com/poketwo/guiduck/pull/69) where lock/unlock commands could report false success or cause infinite loops when permission changes fail.

**Lock command**: Moderator confirmation message ("🔒 Locked #channel") is now built *after* `set_permissions` succeeds. Previously it was built before the permission change, so a `Forbidden` failure would still tell the moderator the channel was locked. On failure, reports "Failed to lock #channel: missing permissions." instead.

**Unlock command**: Merged the two separate loops (validate-all-then-operate-all) into a single per-channel loop so that success/failure messages accurately reflect what actually happened. On `Forbidden`, reports "Failed to unlock #channel: missing permissions."

**`reverse_expired_lock`**: Added `try/except discord.Forbidden` around `set_permissions` to prevent an uncaught exception from blocking the DB update, which previously caused the same expired lock to retry every 30 seconds indefinitely.

**`reverse_expired_lock` race condition**: Made the DB update conditional on `lock_expires_at` matching the original document's value, so a stale auto-unlock task can't overwrite a moderator's re-lock.

## Review & Testing Checklist for Human

- [ ] **Lock announcements on failure**: The lock command sends channel announcements ("🔒 This channel has been locked") *before* `set_permissions` (required because the bot can't send in a locked channel). If the perm change then fails, users in the channel will see a lock announcement but the channel isn't actually locked. The moderator will correctly see "Failed to lock" — verify this tradeoff is acceptable.
- [ ] **`reverse_expired_lock` Forbidden handling**: When `set_permissions` fails with Forbidden, the DB is still updated to `locked: False` (clearing the stale record). This prevents infinite retry but creates a state where the DB says unlocked while Discord perms still have `send_messages=False`. Verify this is preferable to the old infinite-retry behavior.
- [ ] **End-to-end test**: Lock/unlock channels where the bot has and lacks `Manage Permissions`. Verify correct messages for success, failure, already-locked, manually-restricted, and not-locked cases. Test `?lock list` still works. Test auto-unlock expiry if possible.

### Notes
- The lock command's announcement-before-lock timing is an inherent constraint: the bot cannot send messages in a channel after locking it. This was an explicit design decision from the previous PR.
- No CI is configured for this repo.

Link to Devin session: https://app.devin.ai/sessions/8a37bf86ed7841c580d5ca16168d42e6
Requested by: @WitherredAway
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/poketwo/guiduck/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
